### PR TITLE
Dependencies fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,6 @@ Decorators and some other extras for sequelize (v3 + v4).
 npm install sequelize --save // v3
 npm install sequelize@4.0.0-1 --save // or v4
 ```
-and [reflect-metadata](https://www.npmjs.com/package/reflect-metadata)
-```
-npm install reflect-metadata --save
-```
-```
-npm install sequelize-typescript --save 
-```
 Your `tsconfig.json` needs the following flags:
 ```json
 "experimentalDecorators": true,

--- a/package.json
+++ b/package.json
@@ -30,10 +30,14 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@types/node": "6.0.41",
-    "@types/reflect-metadata": "0.0.4",
-    "@types/sequelize": "4.0.39",
-    "es6-shim": "0.35.3"
+    "es6-shim": "0.35.3",
+    "moment": "2.17.1",
+    "mysql": "2.13.0",
+    "reflect-metadata": "0.1.9",
+    "sqlite3": "3.1.8",
+    "lodash": "4.17.4",
+    "uuid-validate": "0.0.2",
+    "prettyjson": "1.2.1"
   },
   "devDependencies": {
     "@types/chai": "3.4.35",
@@ -44,24 +48,20 @@
     "@types/prettyjson": "0.0.28",
     "@types/sinon": "1.16.35",
     "@types/sinon-chai": "2.7.27",
+    "@types/node": "6.0.41",
+    "@types/reflect-metadata": "0.0.4",
+    "@types/sequelize": "4.0.39",
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",
     "chai-datetime": "1.4.1",
     "codecov": "2.1.0",
-    "lodash": "4.17.4",
     "mocha": "3.2.0",
-    "moment": "2.17.1",
-    "mysql": "2.13.0",
     "nyc": "10.1.2",
-    "prettyjson": "1.2.1",
-    "reflect-metadata": "0.1.9",
     "sinon": "1.17.7",
     "sinon-chai": "2.8.0",
     "source-map-support": "0.4.14",
-    "sqlite3": "3.1.8",
     "tslint": "4.3.1",
-    "typescript": "2.2.1",
-    "uuid-validate": "0.0.2"
+    "typescript": "2.2.1"
   },
   "engines": {
     "node": ">=0.8.15"


### PR DESCRIPTION
PR to fix #8 
I'm not sure how to test this.

Also, I've noticed that there is also a dependency for sequelize package note in readme. Wouldn't it be better that this package be a standalone sequelize TS wrapper, and that it should include sequelize by default? Just a thought.