### PR TITLE
Bumped @types/sequelize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,11 @@
       "integrity": "sha1-EhNEEGcsFkO9qlrKIzmw43F68Yg=",
       "dev": true
     },
+    "@types/geojson": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.2.tgz",
+      "integrity": "sha1-sC0QqwKOKSisWSoFGqpJgaGUHQM="
+    },
     "@types/lodash": {
       "version": "4.14.54",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.54.tgz",
@@ -60,9 +65,9 @@
       "integrity": "sha1-tkd8qal+UmXyrGf56nBOrl4Or00="
     },
     "@types/sequelize": {
-      "version": "4.0.58",
-      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.0.58.tgz",
-      "integrity": "sha512-60xm7No9OLKWRo9XZUv88DBdFzD9kNZhNqGXs88No5Cg/CUlHfFxMSAH6FumjcG8G7SpPB0chpFozibWQw9jBA=="
+      "version": "4.0.59",
+      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.0.59.tgz",
+      "integrity": "sha512-pLgy0HIPXbvPnIe0gU1U22jOEZwS94ymi6aqcrIjzSpjoN+JU10+g7farJaKnakC+1dwV6w7o+clVw2R8BW3Yw=="
     },
     "@types/sinon": {
       "version": "1.16.35",
@@ -171,6 +176,11 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-3.1.2.tgz",
       "integrity": "sha1-8725mtUmihX8HwvtL7AY4mk/4jY=",
       "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
     },
     "boom": {
       "version": "2.10.1",
@@ -312,6 +322,16 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true
     },
+    "cross-env": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-3.2.4.tgz",
+      "integrity": "sha1-ngWF8neGTtQhznVvgamA/w1piro="
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk="
+    },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -335,8 +355,7 @@
     "debug": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-      "dev": true
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
     },
     "deep-eql": {
       "version": "0.1.3",
@@ -364,6 +383,11 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "depd": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+    },
     "diff": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
@@ -375,6 +399,11 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "dev": true
+    },
+    "dottie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-1.1.1.tgz",
+      "integrity": "sha1-RcKj9IvWUo7u0memmoSOqspvqmo="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -500,6 +529,11 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true
     },
+    "generic-pool": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.2.tgz",
+      "integrity": "sha1-iGvFvwvrfblugby7oHiBjeWmJoM="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -606,6 +640,11 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "inflection": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz",
+      "integrity": "sha1-W//LEZetPoEFD44X4hZoCH7p6y8="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -690,11 +729,21 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-windows": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk="
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
@@ -844,6 +893,11 @@
       "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true
     },
+    "lru-cache": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4="
+    },
     "make-error": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
@@ -897,14 +951,17 @@
     "moment": {
       "version": "2.17.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
-      "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI=",
-      "dev": true
+      "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI="
+    },
+    "moment-timezone": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
+      "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A="
     },
     "ms": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-      "dev": true
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
     },
     "mysql": {
       "version": "2.13.0",
@@ -1979,6 +2036,11 @@
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -2073,6 +2135,11 @@
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
       "dev": true
     },
+    "retry-as-promised": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.2.0.tgz",
+      "integrity": "sha1-sEY9f9PPWy/tZFAKtui4pJxbjmw="
+    },
     "safe-buffer": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
@@ -2088,14 +2155,45 @@
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true
+    },
+    "sequelize": {
+      "version": "4.0.0-1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.0.0-1.tgz",
+      "integrity": "sha1-6bWSy+zod3ZSqxy12NFRvsCNeFg=",
+      "dependencies": {
+        "lodash": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+          "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk="
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        }
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo="
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shimmer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
+      "integrity": "sha1-l9c3cTf/u6tCVSLkKf4KqJpIizU="
     },
     "sinon": {
       "version": "1.17.7",
@@ -3150,11 +3248,26 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
+    "terraformer": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
+      "integrity": "sha1-UeCtiXRvzyFh3G9lqnDkI3fItZM="
+    },
+    "terraformer-wkt-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.1.2.tgz",
+      "integrity": "sha1-M2oMj8gglKWv+DKI9prt7NNpvww="
+    },
     "timed-out": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
       "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
       "dev": true
+    },
+    "toposort-class": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
     },
     "tough-cookie": {
       "version": "2.3.2",
@@ -3307,17 +3420,32 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true
     },
+    "validator": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-5.7.0.tgz",
+      "integrity": "sha1-eoelgUa2laxIYHEUHAxJ1n2gXlw="
+    },
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
       "dev": true
     },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
+    },
     "widest-line": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "dev": true
+    },
+    "wkx": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.3.0.tgz",
+      "integrity": "sha1-TySUjYeaymXlAWdEaYVeBMKteN0="
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -3348,6 +3476,11 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yn": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3359 @@
+{
+  "name": "sequelize-typescript",
+  "version": "0.3.1",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@types/bluebird": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-aBVzCAzfyApU0gg36QgCpJixGtYwuQ4djrn11J+DTB5vE4OmBPuZiulgTCA9ByULgVAyNV2CTpjjvZmxzukSLw=="
+    },
+    "@types/chai": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.4.35.tgz",
+      "integrity": "sha1-6NZfg0ktKUT4FvxiB0GCHCioyQA=",
+      "dev": true
+    },
+    "@types/chai-as-promised": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-0.0.29.tgz",
+      "integrity": "sha1-Q9UokqqZjhhaPePiR37bhXO+HXc=",
+      "dev": true
+    },
+    "@types/chai-datetime": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/chai-datetime/-/chai-datetime-0.0.30.tgz",
+      "integrity": "sha1-EhNEEGcsFkO9qlrKIzmw43F68Yg=",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.54",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.54.tgz",
+      "integrity": "sha1-KH27zZfV2mnCXKmfta+oHEg5t/o="
+    },
+    "@types/mocha": {
+      "version": "2.2.39",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.39.tgz",
+      "integrity": "sha1-9o1j24tpw46VWLQHNSXPlsT3qCk=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "6.0.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.41.tgz",
+      "integrity": "sha1-V4z1Oq7GWIe8rxZ5L4ciky6P+Oo="
+    },
+    "@types/prettyjson": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@types/prettyjson/-/prettyjson-0.0.28.tgz",
+      "integrity": "sha1-ExqJDe1kIbG1RfRRCkrqvG1GUnU=",
+      "dev": true
+    },
+    "@types/promises-a-plus": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/@types/promises-a-plus/-/promises-a-plus-0.0.27.tgz",
+      "integrity": "sha1-xkZRE0YUyEuPXXEUzokB02pgl4A=",
+      "dev": true
+    },
+    "@types/reflect-metadata": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/reflect-metadata/-/reflect-metadata-0.0.4.tgz",
+      "integrity": "sha1-tkd8qal+UmXyrGf56nBOrl4Or00="
+    },
+    "@types/sequelize": {
+      "version": "4.0.58",
+      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.0.58.tgz",
+      "integrity": "sha512-60xm7No9OLKWRo9XZUv88DBdFzD9kNZhNqGXs88No5Cg/CUlHfFxMSAH6FumjcG8G7SpPB0chpFozibWQw9jBA=="
+    },
+    "@types/sinon": {
+      "version": "1.16.35",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-1.16.35.tgz",
+      "integrity": "sha1-7mh8xC0aeUSCVvHAEqM6CEDoXFw=",
+      "dev": true
+    },
+    "@types/sinon-chai": {
+      "version": "2.7.27",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.27.tgz",
+      "integrity": "sha1-63cpBY3fJTppeeVZuytJEISWmqE=",
+      "dev": true
+    },
+    "@types/validator": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-6.2.0.tgz",
+      "integrity": "sha1-AgMi/hkp9piJ62daG9tamDlLcfA="
+    },
+    "ansi-align": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true
+    },
+    "bignumber.js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-3.1.2.tgz",
+      "integrity": "sha1-8725mtUmihX8HwvtL7AY4mk/4jY=",
+      "dev": true
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true
+    },
+    "boxen": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+      "dev": true
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true
+    },
+    "chai-as-promised": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
+      "integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
+      "dev": true
+    },
+    "chai-datetime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/chai-datetime/-/chai-datetime-1.4.1.tgz",
+      "integrity": "sha1-M3n8GNng0A8u1GWZh1JNYhHGQqg=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "codecov": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-2.1.0.tgz",
+      "integrity": "sha1-JfSPnpqnRzthxampNNWVQgpxyt4=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "configstore": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+      "dev": true,
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        }
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "dot-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "dev": true
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.10",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
+          "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true
+    },
+    "es6-shim": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.3.tgz",
+      "integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "dev": true
+    },
+    "filled-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q=",
+      "dev": true
+    },
+    "findup-sync": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true
+        }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+      "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
+      "dev": true
+    },
+    "got": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.10",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
+          "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "dev": true
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jodid25519": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+      "dev": true,
+      "optional": true
+    },
+    "js-tokens": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "latest-version": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+      "dev": true
+    },
+    "lazy-req": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
+      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true
+    },
+    "mocha": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz",
+      "integrity": "sha1-fcT0XlCIB1FxpoiWgU5q6et6heM=",
+      "dev": true,
+      "dependencies": {
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true
+        }
+      }
+    },
+    "moment": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
+      "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI=",
+      "dev": true
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "mysql": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.13.0.tgz",
+      "integrity": "sha1-mY8fjKRuLj3XFJzpgkE2U5hqrkc=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+      "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI=",
+      "dev": true
+    },
+    "node-status-codes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "nyc": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-10.1.2.tgz",
+      "integrity": "sha1-6nrKogojUhAQFgT059VtKEU7AnQ=",
+      "dev": true,
+      "dependencies": {
+        "align-text": {
+          "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "dev": true
+        },
+        "amdefine": {
+          "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "append-transform": {
+          "version": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "dev": true
+        },
+        "archy": {
+          "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true
+        },
+        "arr-flatten": {
+          "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+          "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "arrify": {
+          "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        },
+        "async": {
+          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
+          "integrity": "sha1-uWj4OQkPmovG1Bk4+5bLhPc4eyY=",
+          "dev": true
+        },
+        "babel-generator": {
+          "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.21.0.tgz",
+          "integrity": "sha1-YF8SacSJocdd7sp+oW1D1GVshJQ=",
+          "dev": true
+        },
+        "babel-messages": {
+          "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
+          "integrity": "sha1-v1BHNsqWfm1l7wrbWipflHyODrk=",
+          "dev": true
+        },
+        "babel-runtime": {
+          "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+          "integrity": "sha1-hzAL3PTNdw8JvwBIxkIE4XgG0W8=",
+          "dev": true
+        },
+        "babel-template": {
+          "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+          "integrity": "sha1-4UndGp8Do1+BfdvE0EgZiOfryMo=",
+          "dev": true
+        },
+        "babel-traverse": {
+          "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+          "integrity": "sha1-acY2WATxpPaesSE/hbAKgYuMIa0=",
+          "dev": true
+        },
+        "babel-types": {
+          "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+          "integrity": "sha1-MUuSFoiR7204Brf3qRf9+HwRpLI=",
+          "dev": true
+        },
+        "babylon": {
+          "version": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz",
+          "integrity": "sha1-umXPoagOF1mw6J+1YuJ9zK5wNI4=",
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+          "dev": true
+        },
+        "braces": {
+          "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true
+        },
+        "builtin-modules": {
+          "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "dev": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "wordwrap": {
+              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "commondir": {
+          "version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+          "dev": true
+        },
+        "concat-map": {
+          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
+          "integrity": "sha1-6fPpxuJyjvwmdmlqcOs4L3MQamc=",
+          "dev": true
+        },
+        "core-js": {
+          "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true
+        },
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+          "dev": true
+        },
+        "debug-log": {
+          "version": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "dev": true
+        },
+        "detect-indent": {
+          "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "dev": true
+        },
+        "error-ex": {
+          "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+          "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "expand-brackets": {
+          "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true
+        },
+        "expand-range": {
+          "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+          "dev": true
+        },
+        "extglob": {
+          "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true
+        },
+        "filename-regex": {
+          "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+          "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+          "dev": true
+        },
+        "find-cache-dir": {
+          "version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true
+        },
+        "for-in": {
+          "version": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
+          "integrity": "sha1-yfluib+tGKVFr17D7TUqHZ5bTcg=",
+          "dev": true
+        },
+        "for-own": {
+          "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
+          "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
+          "dev": true
+        },
+        "foreground-child": {
+          "version": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "dev": true
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true
+        },
+        "glob-base": {
+          "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true
+        },
+        "globals": {
+          "version": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
+          "integrity": "sha1-iFmTavADh0EmMFOznQ52yiQeQDQ=",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "handlebars": {
+          "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+          "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
+          "dev": true,
+          "dependencies": {
+            "source-map": {
+              "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "dev": true
+        },
+        "inflight": {
+          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true
+        },
+        "inherits": {
+          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "invariant": {
+          "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "dev": true
+        },
+        "is-dotfile": {
+          "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+          "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+          "dev": true
+        },
+        "is-equal-shallow": {
+          "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+          "dev": true
+        },
+        "is-extendable": {
+          "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-finite": {
+          "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true
+        },
+        "is-number": {
+          "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true
+        },
+        "is-posix-bracket": {
+          "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isexe": {
+          "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+          "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.1.tgz",
+          "integrity": "sha1-8mPvtRnAUcXx8zQwNPxA57Q/8hI=",
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0.tgz",
+          "integrity": "sha1-/FNn7if1kmjo8GCwx6rwUdnEJcU=",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.4.2.tgz",
+          "integrity": "sha1-Di/frJPB2r8uMVeGN9x4oZCJ9D4=",
+          "dev": true
+        },
+        "istanbul-lib-report": {
+          "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz",
+          "integrity": "sha1-MtX27H8zyjpgIgnieLLm/xQ0mK8=",
+          "dev": true,
+          "dependencies": {
+            "supports-color": {
+              "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "dev": true
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.1.0.tgz",
+          "integrity": "sha1-nUKSGPNbgjVg6jAKlv8MO72reF8=",
+          "dev": true
+        },
+        "istanbul-reports": {
+          "version": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0.tgz",
+          "integrity": "sha1-JLTrKx0p1Q8QOzab1CL25kCqB3c=",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
+          "integrity": "sha1-eZA/VWPud4zBFi5tzxoAJ8l/nLU=",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+          "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
+          "dev": true
+        },
+        "lazy-cache": {
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "longest": {
+          "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "dev": true,
+          "dependencies": {
+            "js-tokens": {
+              "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+              "integrity": "sha1-ovKpacquFC+zzVYig1jIk2aVe9E=",
+              "dev": true
+            }
+          }
+        },
+        "lru-cache": {
+          "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+          "dev": true
+        },
+        "md5-hex": {
+          "version": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "dev": true
+        },
+        "md5-o-matic": {
+          "version": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+          "dev": true
+        },
+        "merge-source-map": {
+          "version": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
+          "integrity": "sha1-2hQV8nIqURnbB7FMT5c0EIY6Kr8=",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+          "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+          "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
+          "dev": true
+        },
+        "number-is-nan": {
+          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "object.omit": {
+          "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "dev": true
+        },
+        "once": {
+          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true
+        },
+        "optimist": {
+          "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true
+        },
+        "os-homedir": {
+          "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true
+        },
+        "parse-glob": {
+          "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "path-parse": {
+          "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true
+        },
+        "pify": {
+          "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "dev": true
+        },
+        "preserve": {
+          "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "dev": true
+        },
+        "randomatic": {
+          "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+          "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
+          "integrity": "sha1-JX9BlhzkRVixj3gUr0jBdVn5+us=",
+          "dev": true
+        },
+        "regex-cache": {
+          "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+          "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+          "dev": true
+        },
+        "repeat-element": {
+          "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "dev": true
+        },
+        "repeating": {
+          "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "dev": true
+        },
+        "require-directory": {
+          "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "dev": true
+        },
+        "right-align": {
+          "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+          "dev": true,
+          "optional": true
+        },
+        "rimraf": {
+          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "dev": true
+        },
+        "semver": {
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true
+        },
+        "slide": {
+          "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
+          "integrity": "sha1-kg6yEadpwJPuv71bDnpdLmirLkA=",
+          "dev": true,
+          "dependencies": {
+            "signal-exit": {
+              "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
+              "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
+              "dev": true
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "https://registry.npmjs.org/test-exclude/-/test-exclude-3.3.0.tgz",
+          "integrity": "sha1-ehfKEjmYjJg2ewYhRW27fUvDiXc=",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+          "integrity": "sha1-8/XAw7pymafvmUJ+RGMyV63kMyA=",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+          "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "async": {
+              "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+              "dev": true,
+              "optional": true
+            },
+            "yargs": {
+              "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+          "dev": true,
+          "optional": true
+        },
+        "validate-npm-package-license": {
+          "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "dev": true
+        },
+        "which": {
+          "version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+          "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
+          "dev": true
+        },
+        "which-module": {
+          "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "window-size": {
+          "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true
+        },
+        "wrappy": {
+          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
+          "integrity": "sha1-fUW6MjFjKN0ex9kPYOvA2EW7dZo=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yallist": {
+          "version": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
+          "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "dev": true,
+          "dependencies": {
+            "camelcase": {
+              "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "dev": true
+            },
+            "cliui": {
+              "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "dev": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "dev": true,
+          "dependencies": {
+            "camelcase": {
+              "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "dev": true
+    },
+    "package-json": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "prettyjson": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
+      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
+    },
+    "rc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "read-all-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.10",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
+          "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true
+    },
+    "reflect-metadata": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.9.tgz",
+      "integrity": "sha1-mHI43IelFolf5FfxMENf+9djpNQ=",
+      "dev": true
+    },
+    "registry-auth-token": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "dev": true
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+      "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "dev": true
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true
+    },
+    "sinon-chai": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
+      "integrity": "sha1-Qyqbv9Uab8AHmPTSUmqCnAYGh6w=",
+      "dev": true
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+      "integrity": "sha1-nURjdyWYuGJxtPUj9sH04Cp9au8=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
+      "dev": true
+    },
+    "sqlite3": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.8.tgz",
+      "integrity": "sha1-TLz5Zdi5AdGxAVy8f8QVquFX36o=",
+      "dev": true,
+      "dependencies": {
+        "node-pre-gyp": {
+          "version": "0.6.31",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.31.tgz",
+          "integrity": "sha1-2KAN2qMBqUBhXbzIyq1AJNWPYBc=",
+          "dev": true,
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true,
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                  "dev": true
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "dev": true,
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+                  "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+                  "dev": true
+                }
+              }
+            },
+            "npmlog": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
+              "integrity": "sha1-4JRQOWHHDBd063ZpIIDo1Xip+I8=",
+              "dev": true,
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                  "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+                  "dev": true,
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                      "dev": true
+                    },
+                    "readable-stream": {
+                      "version": "2.1.5",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+                      "dev": true,
+                      "dependencies": {
+                        "buffer-shims": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                          "dev": true
+                        },
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                          "dev": true
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "dev": true
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                  "dev": true
+                },
+                "gauge": {
+                  "version": "2.6.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                  "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
+                  "dev": true,
+                  "dependencies": {
+                    "aproba": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+                      "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA=",
+                      "dev": true
+                    },
+                    "has-color": {
+                      "version": "0.1.7",
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+                      "dev": true
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                      "dev": true
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                      "dev": true
+                    },
+                    "signal-exit": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+                      "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE=",
+                      "dev": true
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                      "dev": true,
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
+                          "integrity": "sha1-EQTNNPm1tF0+uojxurwZJOHONfs=",
+                          "dev": true,
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                          "dev": true,
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "dev": true,
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+                      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                  "dev": true
+                }
+              }
+            },
+            "rc": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+              "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+              "dev": true,
+              "dependencies": {
+                "deep-extend": {
+                  "version": "0.4.1",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+                  "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
+                  "dev": true
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                  "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+                  "dev": true
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                  "dev": true
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+                  "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+                  "dev": true
+                }
+              }
+            },
+            "request": {
+              "version": "2.76.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
+              "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
+              "dev": true,
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                  "dev": true
+                },
+                "aws4": {
+                  "version": "1.5.0",
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+                  "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
+                  "dev": true
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                  "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                  "dev": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "dev": true,
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                      "dev": true
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                  "dev": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                  "dev": true
+                },
+                "form-data": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.1.tgz",
+                  "integrity": "sha1-St8DQuGnmvoehMjDIKn/yCOSofM=",
+                  "dev": true,
+                  "dependencies": {
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                      "dev": true
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                  "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                  "dev": true,
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                      "dev": true,
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                          "dev": true
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                          "dev": true
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                          "dev": true,
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                          "dev": true,
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                      "dev": true,
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.15.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                      "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+                      "dev": true,
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                          "dev": true
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                          "dev": true,
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "4.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+                          "integrity": "sha1-ZmHhYdL8RF8Z+YQwIxNDci4fy9U=",
+                          "dev": true
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "dev": true,
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                  "dev": true,
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "dev": true
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                      "dev": true
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                      "dev": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                      "dev": true
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                  "dev": true,
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "dev": true
+                    },
+                    "jsprim": {
+                      "version": "1.3.1",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                      "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+                      "dev": true,
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                          "dev": true
+                        },
+                        "json-schema": {
+                          "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                          "dev": true
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.10.1",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                      "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
+                      "dev": true,
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                          "dev": true
+                        },
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                          "dev": true
+                        },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                          "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "dashdash": {
+                          "version": "1.14.0",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                          "dev": true
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "getpass": {
+                          "version": "0.1.6",
+                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                          "dev": true
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.3",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                          "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                  "dev": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                  "dev": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                  "dev": true
+                },
+                "mime-types": {
+                  "version": "2.1.12",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
+                  "dev": true,
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.24.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                      "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww=",
+                      "dev": true
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+                  "dev": true
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                  "dev": true
+                },
+                "qs": {
+                  "version": "6.3.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+                  "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI=",
+                  "dev": true
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                  "dev": true
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+                  "dev": true,
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.4.1",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                      "dev": true
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.4.3",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                  "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+                  "dev": true
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.5.4",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+              "dev": true,
+              "dependencies": {
+                "glob": {
+                  "version": "7.1.1",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                  "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+                  "dev": true,
+                  "dependencies": {
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                      "dev": true
+                    },
+                    "inflight": {
+                      "version": "1.0.6",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                      "dev": true,
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "dev": true,
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                          "dev": true,
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                              "dev": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                      "dev": true,
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+              "dev": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+              "dev": true,
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+                  "dev": true
+                },
+                "fstream": {
+                  "version": "1.0.10",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+                  "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+                  "dev": true,
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.9",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                      "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                      "dev": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "dev": true
+                }
+              }
+            },
+            "tar-pack": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+              "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
+              "dev": true,
+              "dependencies": {
+                "debug": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                  "dev": true,
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                      "dev": true
+                    }
+                  }
+                },
+                "fstream": {
+                  "version": "1.0.10",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+                  "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+                  "dev": true,
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.9",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                      "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    }
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+                  "dev": true,
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "dev": true,
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                          "dev": true,
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                              "dev": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "dev": true,
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.1.5",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                  "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+                  "dev": true,
+                  "dependencies": {
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                      "dev": true
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "dev": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+                  "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "sqlstring": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.2.0.tgz",
+      "integrity": "sha1-wxNcTqirzX5+50GklmqJHYak8ZE=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "timed-out": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "dev": true
+    },
+    "ts-node": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.0.4.tgz",
+      "integrity": "sha1-oUdevyT9Ti7i+6ixqhYFuXe95QY=",
+      "dev": true,
+      "dependencies": {
+        "diff": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "tsconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
+      "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
+      "dev": true
+    },
+    "tslint": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.3.1.tgz",
+      "integrity": "sha1-KPZ5xTyksnNoi8tvzw3ef/G7IWk=",
+      "dev": true,
+      "dependencies": {
+        "diff": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz",
+      "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
+      "dev": true
+    },
+    "underscore.string": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "dev": true
+    },
+    "unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+      "dev": true
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true
+    },
+    "urlgrey": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
+      "dev": true
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+      "dev": true
+    },
+    "uuid-validate": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/uuid-validate/-/uuid-validate-0.0.2.tgz",
+      "integrity": "sha1-7Yg9Js8NGBl2Or+jFelibdtnyOg=",
+      "dev": true
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "dev": true
+    },
+    "widest-line": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "dev": true
+    },
+    "xdg-basedir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yn": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-1.3.0.tgz",
+      "integrity": "sha1-GwgSq7jYBdSJZvjfOF3J2syaGdg=",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,11 +26,6 @@
       "integrity": "sha1-EhNEEGcsFkO9qlrKIzmw43F68Yg=",
       "dev": true
     },
-    "@types/geojson": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.2.tgz",
-      "integrity": "sha1-sC0QqwKOKSisWSoFGqpJgaGUHQM="
-    },
     "@types/lodash": {
       "version": "4.14.54",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.54.tgz",
@@ -177,11 +172,6 @@
       "integrity": "sha1-8725mtUmihX8HwvtL7AY4mk/4jY=",
       "dev": true
     },
-    "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-    },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
@@ -322,16 +312,6 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true
     },
-    "cross-env": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-3.2.4.tgz",
-      "integrity": "sha1-ngWF8neGTtQhznVvgamA/w1piro="
-    },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk="
-    },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -355,7 +335,8 @@
     "debug": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true
     },
     "deep-eql": {
       "version": "0.1.3",
@@ -383,11 +364,6 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
-    "depd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
-    },
     "diff": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
@@ -399,11 +375,6 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "dev": true
-    },
-    "dottie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-1.1.1.tgz",
-      "integrity": "sha1-RcKj9IvWUo7u0memmoSOqspvqmo="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -529,11 +500,6 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true
     },
-    "generic-pool": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.2.tgz",
-      "integrity": "sha1-iGvFvwvrfblugby7oHiBjeWmJoM="
-    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -640,11 +606,6 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "inflection": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz",
-      "integrity": "sha1-W//LEZetPoEFD44X4hZoCH7p6y8="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -729,21 +690,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
-    "is-windows": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
-      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk="
-    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
@@ -893,11 +844,6 @@
       "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true
     },
-    "lru-cache": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4="
-    },
     "make-error": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
@@ -951,17 +897,14 @@
     "moment": {
       "version": "2.17.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
-      "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI="
-    },
-    "moment-timezone": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
-      "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A="
+      "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI=",
+      "dev": true
     },
     "ms": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
     },
     "mysql": {
       "version": "2.13.0",
@@ -2036,11 +1979,6 @@
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -2135,11 +2073,6 @@
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
       "dev": true
     },
-    "retry-as-promised": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.2.0.tgz",
-      "integrity": "sha1-sEY9f9PPWy/tZFAKtui4pJxbjmw="
-    },
     "safe-buffer": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
@@ -2155,45 +2088,14 @@
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true
-    },
-    "sequelize": {
-      "version": "4.0.0-1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.0.0-1.tgz",
-      "integrity": "sha1-6bWSy+zod3ZSqxy12NFRvsCNeFg=",
-      "dependencies": {
-        "lodash": {
-          "version": "4.15.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
-          "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk="
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        }
-      }
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo="
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "shimmer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
-      "integrity": "sha1-l9c3cTf/u6tCVSLkKf4KqJpIizU="
     },
     "sinon": {
       "version": "1.17.7",
@@ -3248,26 +3150,11 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
-    "terraformer": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
-      "integrity": "sha1-UeCtiXRvzyFh3G9lqnDkI3fItZM="
-    },
-    "terraformer-wkt-parser": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.1.2.tgz",
-      "integrity": "sha1-M2oMj8gglKWv+DKI9prt7NNpvww="
-    },
     "timed-out": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
       "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
       "dev": true
-    },
-    "toposort-class": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
-      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
     },
     "tough-cookie": {
       "version": "2.3.2",
@@ -3420,32 +3307,17 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true
     },
-    "validator": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-5.7.0.tgz",
-      "integrity": "sha1-eoelgUa2laxIYHEUHAxJ1n2gXlw="
-    },
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
       "dev": true
     },
-    "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
-    },
     "widest-line": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "dev": true
-    },
-    "wkx": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.3.0.tgz",
-      "integrity": "sha1-TySUjYeaymXlAWdEaYVeBMKteN0="
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -3476,11 +3348,6 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yn": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@types/node": "6.0.41",
     "@types/reflect-metadata": "0.0.4",
-    "@types/sequelize": "4.0.39",
+    "@types/sequelize": "4.0.58",
     "es6-shim": "0.35.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "@types/node": "6.0.41",
     "@types/reflect-metadata": "0.0.4",
     "@types/sequelize": "4.0.59",
-    "es6-shim": "0.35.3",
-    "sequelize": "4.0.0-1"
+    "es6-shim": "0.35.3"
   },
   "devDependencies": {
     "@types/chai": "3.4.35",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   "dependencies": {
     "@types/node": "6.0.41",
     "@types/reflect-metadata": "0.0.4",
-    "@types/sequelize": "4.0.58",
-    "es6-shim": "0.35.3"
+    "@types/sequelize": "4.0.59",
+    "es6-shim": "0.35.3",
+    "sequelize": "4.0.0-1"
   },
   "devDependencies": {
     "@types/chai": "3.4.35",


### PR DESCRIPTION
`@types/sequelize` got an update, and I let npm [generate the package-lock.json](https://docs.npmjs.com/files/package-lock.json) file that npm v5 throws in the root of the project now.

I tried running the tests, but I got a weird error.
```
> SEQ_SILENT=true mocha 'test/specs/**/*.js'                      
                                                                  
'SEQ_SILENT' is not recognized as an internal or external command,
operable program or batch file.                                   
```

Windows 10 64bit
Node.js: **8.0.0**
NPM: **v5.0.2**
Typescript: **v2.3.2**

I want to see if the test passes on travis, then it's probably a windows/environment thing.