### PR TITLE
Filter out ts definitions

### DIFF
--- a/lib/services/models.ts
+++ b/lib/services/models.ts
@@ -170,8 +170,9 @@ export function getModels(arg: Array<typeof Model|string>): Array<typeof Model> 
       const _models = fs
         .readdirSync(dir as string)
         .filter(file => {
+          // TODO extension is not necessarily only the lasst three characters
           const extension = file.slice(-3);
-          return extension === '.js' || (extension === '.ts' && file.slice(-4) !== '.d.ts');
+          return extension === '.js' || (extension === '.ts' && file.slice(-5) !== '.d.ts');
         })
         .map(file => path.parse(file).name)
         .filter(uniqueFilter)

--- a/lib/services/models.ts
+++ b/lib/services/models.ts
@@ -153,7 +153,7 @@ export function getSequelizeTypeByDesignType(target: any, propertyName: string):
     return dataType;
   }
 
-  throw new Error(`Specified type of property '${propertyName}' 
+  throw new Error(`Specified type of property '${propertyName}'
             cannot be automatically resolved to a sequelize data type. Please
             define the data type manually`);
 }
@@ -171,7 +171,7 @@ export function getModels(arg: Array<typeof Model|string>): Array<typeof Model> 
         .readdirSync(dir as string)
         .filter(file => {
           const extension = file.slice(-3);
-          return extension === '.js' || extension === '.ts';
+          return extension === '.js' || (extension === '.ts' && file.slice(-4) !== '.d.ts');
         })
         .map(file => path.parse(file).name)
         .filter(uniqueFilter)

--- a/test/specs/models/sequelize.spec.ts
+++ b/test/specs/models/sequelize.spec.ts
@@ -58,6 +58,16 @@ describe('sequelize', () => {
 
     });
 
+    describe('definition files', () => {
+      it('should not load in definition files', () => {
+        sequelize.addModels([__dirname + '/../../models/exports/']);
+
+        expect(() => Game.build({})).not.to.throw;
+
+        expect(Object.keys(sequelize.models).length).to.equal(2);
+      });
+    });
+
   });
 
   describe('model', () => {


### PR DESCRIPTION
Only adds filter predicate to test against the `.d.ts` extension. It is also worth mentioning, although not applicable currently, that the `extension` local variable in `models.ts` isn't necessarily the extension if the directory has files with longer extensions (for example, the .d.ts extension needs that splice(-5)). Just a minor nit picky thing, can fix later (we're not expecting any other file types other than .js/.ts/.d.ts).

Added a comment/TODO for it for future reference.

Closes #23 