### PR TITLE
allow additional options to be specified for associations

### DIFF
--- a/lib/annotations/ForeignKey.ts
+++ b/lib/annotations/ForeignKey.ts
@@ -1,10 +1,17 @@
+import {AssociationForeignKeyOptions} from 'sequelize';
 import {Model} from "../models/Model";
 import {addForeignKey} from "../services/association";
 
-export function ForeignKey(relatedClassGetter: () => typeof Model): Function {
+export function ForeignKey(relatedClassGetter: () => typeof Model, options?: AssociationForeignKeyOptions): Function {
 
   return (target: any, propertyName: string) => {
 
-    addForeignKey(target, relatedClassGetter, propertyName);
+    if (!options) {
+      options = {name: propertyName};
+    } else if (!options.name) {
+      options.name = propertyName;
+    }
+
+    addForeignKey(target, relatedClassGetter, options);
   };
 }

--- a/lib/annotations/association/BelongsTo.ts
+++ b/lib/annotations/association/BelongsTo.ts
@@ -1,17 +1,23 @@
+import {AssociationOptionsBelongsTo} from 'sequelize';
+
 import {Model} from "../../models/Model";
 import {BELONGS_TO, addAssociation} from "../../services/association";
 
 export function BelongsTo(relatedClassGetter: () => typeof Model,
-                          foreignKey?: string): Function {
+                          options?: string | AssociationOptionsBelongsTo): Function {
 
   return (target: any, propertyName: string) => {
+
+    if (typeof options === 'string') {
+      options = {foreignKey: {name: options}};
+    }
 
     addAssociation(
       target,
       BELONGS_TO,
       relatedClassGetter,
       propertyName,
-      foreignKey
+      options
     );
   };
 }

--- a/lib/annotations/association/BelongsToMany.ts
+++ b/lib/annotations/association/BelongsToMany.ts
@@ -1,19 +1,24 @@
+import {AssociationOptionsBelongsToMany} from 'sequelize';
+
 import {Model} from "../../models/Model";
 import {BELONGS_TO_MANY, addAssociation} from "../../services/association";
 
 export function BelongsToMany(relatedClassGetter: () => typeof Model,
                               through: (() => typeof Model)|string,
-                              foreignKey?: string,
+                              options?: string | AssociationOptionsBelongsToMany,
                               otherKey?: string): Function {
 
   return (target: any, propertyName: string) => {
-
+    if (typeof options === 'string') {
+      // don't worry, through is mainly here to avoid TS error; actual through value is resolved later
+      options = {through: '', foreignKey: {name: options}};
+    }
     addAssociation(
       target,
       BELONGS_TO_MANY,
       relatedClassGetter,
       propertyName,
-      foreignKey,
+      options,
       otherKey,
       through
     );

--- a/lib/annotations/association/HasMany.ts
+++ b/lib/annotations/association/HasMany.ts
@@ -1,17 +1,21 @@
+import {AssociationOptionsHasMany} from 'sequelize';
+
 import {Model} from "../../models/Model";
 import {HAS_MANY, addAssociation} from "../../services/association";
 
 export function HasMany(relatedClassGetter: () => typeof Model,
-                        foreignKey?: string): Function {
+                        options?: string | AssociationOptionsHasMany): Function {
 
   return (target: any, propertyName: string) => {
-
+    if (typeof options === 'string') {
+      options = {foreignKey: {name: options}};
+    }
     addAssociation(
       target,
       HAS_MANY,
       relatedClassGetter,
       propertyName,
-      foreignKey
+      options
     );
   };
 }

--- a/lib/annotations/association/HasOne.ts
+++ b/lib/annotations/association/HasOne.ts
@@ -1,17 +1,21 @@
+import {AssociationOptionsHasOne} from 'sequelize';
+
 import {Model} from "../../models/Model";
 import {addAssociation, HAS_ONE} from "../../services/association";
 
 export function HasOne(relatedClassGetter: () => typeof Model,
-                       foreignKey?: string): Function {
+                       options?: string | AssociationOptionsHasOne): Function {
 
   return (target: any, propertyName: string) => {
-
+    if (typeof options === 'string') {
+      options = {foreignKey: {name: options}};
+    }
     addAssociation(
       target,
       HAS_ONE,
       relatedClassGetter,
       propertyName,
-      foreignKey
+      options
     );
   };
 }

--- a/lib/interfaces/ISequelizeAssociation.ts
+++ b/lib/interfaces/ISequelizeAssociation.ts
@@ -1,3 +1,5 @@
+import {AssociationOptionsBelongsTo, AssociationOptionsBelongsToMany, AssociationOptionsHasMany,
+  AssociationOptionsHasOne, AssociationOptionsManyToMany} from 'sequelize';
 import {Model} from "../models/Model";
 
 export interface ISequelizeAssociation {
@@ -6,7 +8,8 @@ export interface ISequelizeAssociation {
   relatedClassGetter: () => typeof Model;
   through?: string;
   throughClassGetter?: () => typeof Model;
-  foreignKey?: string;
+  options?: AssociationOptionsBelongsTo | AssociationOptionsBelongsToMany | AssociationOptionsHasMany |
+    AssociationOptionsHasOne | AssociationOptionsManyToMany;
   otherKey?: string;
   as: string;
 }

--- a/lib/interfaces/ISequelizeForeignKeyConfig.ts
+++ b/lib/interfaces/ISequelizeForeignKeyConfig.ts
@@ -1,7 +1,8 @@
+import {AssociationForeignKeyOptions} from 'sequelize';
 import {Model} from "../models/Model";
 
 export interface ISequelizeForeignKeyConfig {
 
   relatedClassGetter: () => typeof Model;
-  foreignKey: string;  
+  options: string | AssociationForeignKeyOptions;
 }

--- a/test/specs/association.spec.ts
+++ b/test/specs/association.spec.ts
@@ -729,6 +729,31 @@ describe('association', () => {
 
       oneToManyWithOptionsTestSuites(Book4, Page4, true);
     });
+
+    describe('set foreign keys explicitly via options', () => {
+
+      @Table
+      class Book5 extends Model<Book5> {
+
+        @Column
+        title: string;
+
+        @HasMany(() => Page5, {foreignKey: 'bookId'})
+        pages: Page5[];
+      }
+
+      @Table
+      class Page5 extends Model<Page5> {
+
+        @Column(DataType.TEXT)
+        content: string;
+
+        @BelongsTo(() => Book5, {foreignKey: 'bookId'})
+        book: Book5;
+      }
+
+      oneToManyTestSuites(Book5, Page5);
+    });
   });
 
   describe('Many-to-many', () => {
@@ -1722,6 +1747,40 @@ describe('association', () => {
       }
 
       oneToOneWithOptionsTestSuites(User4, Address4, true);
+    });
+
+    describe('set foreign keys explicitly via options', () => {
+
+      @Table
+      class User5 extends Model<User5> {
+
+        @Column
+        name: string;
+
+        @HasOne(() => Address5, {foreignKey: 'userId'})
+        address: any;
+      }
+
+      @Table
+      class Address5 extends Model<Address5> {
+
+        @Column
+        street: string;
+
+        @Column
+        zipCode: string;
+
+        @Column
+        city: string;
+
+        @Column
+        country: string;
+
+        @BelongsTo(() => User5, {foreignKey: 'userId'})
+        user: User5;
+      }
+
+      oneToOneTestSuites(User5, Address5);
     });
   });
 


### PR DESCRIPTION
Affects `BelongsTo`,  `BelongsToMany`, `HasMany`, `HasOne`, and `ForeignKey` attributes. Compatibility with existing parameter that takes string name of foreign keys has been provided by letting the foreign key be a string (existing functionality) or the appropriate association options (new functionality). Additionally, `ForeignKey` can now receive options. By default it simply sets the foreign key name to the property name, which should be backwards compatible.

I did not add tests for the Many-to-Many cases, because additional options outside setting the FK column names and table name are mostly superfluous.

Fixes #34