### PR TITLE
Don’t force the table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ class Person extends Model<Person> {}
 
 Decorator                             | Description
 --------------------------------------|---------------------
- `@Table`                             | sets `options.tableName=<CLASS_NAME>` and  `options.modelName=<CLASS_NAME>` automatically
- `@Table(options: DefineOptions)`     | sets [define options](http://docs.sequelizejs.com/manual/tutorial/models-definition.html#configuration) (also sets `options.tableName=<CLASS_NAME>` and  `options.modelName=<CLASS_NAME>` if not already defined by define options) 
+ `@Table`                             | sets `options.modelName=<CLASS_NAME>` automatically
+ `@Table(options: DefineOptions)`     | sets [define options](http://docs.sequelizejs.com/manual/tutorial/models-definition.html#configuration) (also sets `options.modelName=<CLASS_NAME>` if not already defined by define options)
 
 #### Primary key
 A primary key (`id`) will be inherited from base class `Model`. This primary key is by default an `INTEGER` and has 
@@ -571,7 +571,7 @@ which does not throw an error.
 ### Minification
 If you need to minify your code, you need to set `tableName` and `modelName` 
 in the `DefineOptions` for `@Table` annotation. sequelize-typescript
-uses the class name as default name for `tableName` and `modelName`. 
+uses the class name as default name for `modelName`, and `tableName` is generated from that.
 When the code is minified the class name will no longer be the originally
 defined one (So that `class User` will become `class b` for example).
 

--- a/lib/annotations/Table.ts
+++ b/lib/annotations/Table.ts
@@ -20,8 +20,6 @@ export function Table(arg: any): void|Function {
 
 function annotate(target: any, options: IDefineOptions = {}): void {
 
-  if (!options.tableName) options.tableName = target.name;
-
   options.instanceMethods = target.prototype;
   options.classMethods = target;
 

--- a/test/specs/model.spec.ts
+++ b/test/specs/model.spec.ts
@@ -538,7 +538,7 @@ describe('model', () => {
         expect(idx1.unique).to.be.ok;
 
 
-        expect(idx2.name).to.equal('model_a_field_c');
+        expect(idx2.name).to.equal('model_as_field_c');
         expect(idx2.unique).not.to.be.ok;
 
       });
@@ -1055,7 +1055,7 @@ describe('model', () => {
             fields: ['secretValue'], logging: (sql) => {
               test = true;
               // tslint:disable:max-line-length
-              expect(sql).to.match(/UPDATE\s+[`"]+User[`"]+\s+SET\s+[`"]+secretValue[`"]='43',[`"]+updatedAt[`"]+='[^`",]+'\s+WHERE [`"]+id[`"]+\s=\s1/);
+              expect(sql).to.match(/UPDATE\s+[`"]+Users[`"]+\s+SET\s+[`"]+secretValue[`"]='43',[`"]+updatedAt[`"]+='[^`",]+'\s+WHERE [`"]+id[`"]+\s=\s1/);
             }
           });
         });

--- a/test/specs/table_column.spec.ts
+++ b/test/specs/table_column.spec.ts
@@ -95,12 +95,6 @@ describe('table_column', () => {
       expect(shoeDefineOptions).not.to.be.undefined;
     });
 
-    it('should have automatically inferred tableName', () => {
-      const userDefineOptions = getOptions(User.prototype);
-
-      expect(userDefineOptions).to.have.property('tableName', User.name);
-    });
-
     it('should have explicitly defined tableName', () => {
       const shoeDefineOptions = getOptions(Shoe.prototype);
 
@@ -230,7 +224,7 @@ describe('table_column', () => {
         force: true, logging: _.after(2, _.once((sql) => {
 
           // tslint:disable:max-line-length
-          expect(sql).to.match(/CREATE TABLE IF NOT EXISTS `Bottle` \(`id` INTEGER PRIMARY KEY AUTOINCREMENT, `brand` VARCHAR\(5\), `key` CHAR\(2\), `num` INTEGER\(100\)\)/);
+          expect(sql).to.match(/CREATE TABLE IF NOT EXISTS `Bottles` \(`id` INTEGER PRIMARY KEY AUTOINCREMENT, `brand` VARCHAR\(5\), `key` CHAR\(2\), `num` INTEGER\(100\)\)/);
         }))
       });
     });


### PR DESCRIPTION
If you don’t specify a table name, `sequelize-typescript` uses the class name. This is different from what Sequelize does. One example: for a model `Person`, Sequelize creates the table `People`. But `sequelize-typescript` creates `Person` instead.

By default Sequelize pluralizes table names. There are other options that affect the table name including `underscoredAll` and `freezeTableName`.

By simply not trying to set the table name, you would get the default behavior for free. As far as I can tell, `sequelize-typescript` has no dependency on the specific table name.

This would be a major breaking change, of course, because every model’s table name would change.