### PR TITLE
OptimisticLocking property: number --> number|string

### DIFF
--- a/lib/interfaces/IDefineOptions.ts
+++ b/lib/interfaces/IDefineOptions.ts
@@ -4,7 +4,9 @@ export interface IDefineOptions extends DefineOptions<any> {
   modelName?: string;
 
   /**
-   * To enable optimistic locking.
+   * Enable optimistic locking.  When enabled, sequelize will add a version count attribute
+   * to the model and throw an OptimisticLockingError error when stale instances are saved.
+   * Set to true or a string with the attribute name you want to use to enable.
    */
-  version?: boolean;
+  version?: boolean | string;
 }

--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -469,7 +469,7 @@ export declare class Model<T> extends Hooks {
   /**
    * version number automatically created by sequelize if table options.version is true
    */
-  version?: number;
+  version?: number|any;
 
   /**
    * Returns true if this instance has not yet been persisted to the database


### PR DESCRIPTION
http://docs.sequelizejs.com/manual/tutorial/models-definition.html

```
// Enable optimistic locking.  When enabled, sequelize will add a version count attribute
// to the model and throw an OptimisticLockingError error when stale instances are saved.
// Set to true or a string with the attribute name you want to use to enable.
```

IDefineOptions: as commented above -`Set to true or a string`.
Model.d.ts: if a user sets the version in IDefineOptions to a string (or not set it at all) it is probably to free the version field for something else and in that case it should not be forced to a number (This is the motivation for this pull request - I had a version field of type string which called a build break). 