### PR TITLE
Add support for all UUID versions 

### DIFF
--- a/lib/annotations/association/BelongsToMany.ts
+++ b/lib/annotations/association/BelongsToMany.ts
@@ -20,7 +20,7 @@ export function BelongsToMany(relatedClassGetter: ModelClassGetter,
     through = throughOrOptions;
   } else {
     through = (throughOrOptions as IAssociationOptionsBelongsToMany).through;
-    options = throughOrOptions;
+    options = throughOrOptions as IAssociationOptionsBelongsToMany;
   }
   return (target: any, propertyName: string) => {
     addAssociation(

--- a/lib/annotations/validation/IsUUID.ts
+++ b/lib/annotations/validation/IsUUID.ts
@@ -1,10 +1,12 @@
 import 'reflect-metadata';
 import {addAttributeOptions} from "../../services/models";
 
-/**
- * Only allow uuids
+/*
+ * Only allow uuids.
+ * Version's regular expressions:
+ * https://github.com/chriso/validator.js/blob/b59133b1727b6af355b403a9a97a19226cceb34b/lib/isUUID.js#L14-L19.
  */
-export function IsUUID(version: number): Function {
+export function IsUUID(version: 3|4|5|"3"|"4"|"5"|"all"): Function {
 
   return (target: any, propertyName: string) =>
     addAttributeOptions(target, propertyName, {

--- a/lib/interfaces/IBaseIncludeOptions.ts
+++ b/lib/interfaces/IBaseIncludeOptions.ts
@@ -15,7 +15,7 @@ export interface IBaseIncludeOptions {
    * Where clauses to apply to the child models. Note that this converts the eager load to an inner join,
    * unless you explicitly set `required: false`
    */
-  where?: WhereOptions;
+  where?: WhereOptions<any>;
 
   /**
    * A list of attributes to select from the child model

--- a/lib/interfaces/IFindOptions.ts
+++ b/lib/interfaces/IFindOptions.ts
@@ -11,7 +11,7 @@ export interface IFindOptions extends LoggingOptions, SearchPathOptions {
   /**
    * A hash of attributes to describe your search. See above for examples.
    */
-  where?: WhereOptions | Array<col | and | or | string> | col | and | or | string;
+  where?: WhereOptions<any> | Array<col | and | or | string> | col | and | or | string;
 
   /**
    * A list of the attributes that you want to select. To rename an attribute, you can pass an array, with
@@ -69,7 +69,7 @@ export interface IFindOptions extends LoggingOptions, SearchPathOptions {
   /**
    * having ?!?
    */
-  having?: WhereOptions;
+  having?: WhereOptions<any>;
 
   /**
    * Group by. It is not mentioned in sequelize's JSDoc, but mentioned in docs.

--- a/lib/interfaces/IScopeFindOptions.ts
+++ b/lib/interfaces/IScopeFindOptions.ts
@@ -11,7 +11,7 @@ export interface IScopeFindOptions extends LoggingOptions, SearchPathOptions {
   /**
    * A hash of attributes to describe your search. See above for examples.
    */
-  where?: WhereOptions | Array<col | and | or | string> | col | and | or | string;
+  where?: WhereOptions<any> | Array<col | and | or | string> | col | and | or | string;
 
   /**
    * A list of the attributes that you want to select. To rename an attribute, you can pass an array, with
@@ -69,7 +69,7 @@ export interface IScopeFindOptions extends LoggingOptions, SearchPathOptions {
   /**
    * having ?!?
    */
-  having?: WhereOptions;
+  having?: WhereOptions<any>;
 
   /**
    * Group by. It is not mentioned in sequelize's JSDoc, but mentioned in docs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,9 +68,9 @@
       "integrity": "sha1-tkd8qal+UmXyrGf56nBOrl4Or00="
     },
     "@types/sequelize": {
-      "version": "4.0.60",
-      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.0.60.tgz",
-      "integrity": "sha512-Be2je4WAGyzqGzOihthgqDEnuRTxteKh2QB78UXCpHD4pWR37pTeQRNCZHAko0CySwQbZfhKdQ9L4VtqUVwJCQ==",
+      "version": "4.0.68",
+      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.0.68.tgz",
+      "integrity": "sha512-rarqeMu6s9wbdUxGG16erywZGKrrX4fzgvckpd+88s3EqPKPjTNCyEGzStA8q4mM7avHA/LMxnwBro1+oXKfYw==",
       "requires": {
         "@types/bluebird": "3.5.5",
         "@types/lodash": "4.14.54",
@@ -837,7 +837,7 @@
     "iconv-lite": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI=",
       "dev": true
     },
     "imurmurhash": {
@@ -1135,7 +1135,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -1166,7 +1166,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.7"
@@ -1269,7 +1269,7 @@
         "readable-stream": {
           "version": "2.2.11",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "integrity": "sha1-B5azH412iAB/8Lk6gIjTSqF8D3I=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -1292,7 +1292,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.0"
@@ -1338,7 +1338,7 @@
     "nyc": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.2.tgz",
-      "integrity": "sha512-31rRd6ME9NM17w0oPKqi51a6fzJAqYarnzQXK+iL8XaX+3H6VH0BQut7qHIgrv2mBASRic4oNi2KRgcbFODrsQ==",
+      "integrity": "sha1-nlkqaXGGAoJTtmhRbDjwecOcCPM=",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -3317,8 +3317,7 @@
       "dependencies": {
         "node-pre-gyp": {
           "version": "0.6.31",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.31.tgz",
-          "integrity": "sha1-2KAN2qMBqUBhXbzIyq1AJNWPYBc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mkdirp": "0.5.1",
@@ -3334,8 +3333,7 @@
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -3343,16 +3341,14 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "nopt": {
               "version": "3.0.6",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "abbrev": "1.0.9"
@@ -3360,16 +3356,14 @@
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                  "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "npmlog": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
-              "integrity": "sha1-4JRQOWHHDBd063ZpIIDo1Xip+I8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "are-we-there-yet": "1.1.2",
@@ -3380,8 +3374,7 @@
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-                  "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "delegates": "1.0.0",
@@ -3390,14 +3383,12 @@
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                      "bundled": true,
                       "dev": true
                     },
                     "readable-stream": {
                       "version": "2.1.5",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "buffer-shims": "1.0.0",
@@ -3411,44 +3402,37 @@
                       "dependencies": {
                         "buffer-shims": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                          "bundled": true,
                           "dev": true
                         },
                         "core-util-is": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "bundled": true,
                           "dev": true
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "bundled": true,
                           "dev": true
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                          "bundled": true,
                           "dev": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                          "bundled": true,
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "bundled": true,
                           "dev": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -3457,14 +3441,12 @@
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                  "bundled": true,
                   "dev": true
                 },
                 "gauge": {
                   "version": "2.6.0",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
-                  "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "aproba": "1.0.4",
@@ -3480,38 +3462,32 @@
                   "dependencies": {
                     "aproba": {
                       "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-                      "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA=",
+                      "bundled": true,
                       "dev": true
                     },
                     "has-color": {
                       "version": "0.1.7",
-                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-                      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "has-unicode": {
                       "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                      "bundled": true,
                       "dev": true
                     },
                     "object-assign": {
                       "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                      "bundled": true,
                       "dev": true
                     },
                     "signal-exit": {
                       "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-                      "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE=",
+                      "bundled": true,
                       "dev": true
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "code-point-at": "1.0.1",
@@ -3521,8 +3497,7 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-                          "integrity": "sha1-EQTNNPm1tF0+uojxurwZJOHONfs=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "number-is-nan": "1.0.1"
@@ -3530,16 +3505,14 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "number-is-nan": "1.0.1"
@@ -3547,8 +3520,7 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -3557,8 +3529,7 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "ansi-regex": "2.0.0"
@@ -3566,16 +3537,14 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "wide-align": {
                       "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-                      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "string-width": "1.0.2"
@@ -3585,16 +3554,14 @@
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "rc": {
               "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-              "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "deep-extend": "0.4.1",
@@ -3605,34 +3572,29 @@
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.1",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                  "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
+                  "bundled": true,
                   "dev": true
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+                  "bundled": true,
                   "dev": true
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                  "bundled": true,
                   "dev": true
                 },
                 "strip-json-comments": {
                   "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                  "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "request": {
               "version": "2.76.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
-              "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "aws-sign2": "0.6.0",
@@ -3659,26 +3621,22 @@
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                  "bundled": true,
                   "dev": true
                 },
                 "aws4": {
                   "version": "1.5.0",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
-                  "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
+                  "bundled": true,
                   "dev": true
                 },
                 "caseless": {
                   "version": "0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                  "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                  "bundled": true,
                   "dev": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "delayed-stream": "1.0.0"
@@ -3686,28 +3644,24 @@
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                  "bundled": true,
                   "dev": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                  "bundled": true,
                   "dev": true
                 },
                 "form-data": {
                   "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.1.tgz",
-                  "integrity": "sha1-St8DQuGnmvoehMjDIKn/yCOSofM=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "asynckit": "0.4.0",
@@ -3717,16 +3671,14 @@
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "har-validator": {
                   "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                  "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "chalk": "1.1.3",
@@ -3737,8 +3689,7 @@
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "ansi-styles": "2.2.1",
@@ -3750,20 +3701,17 @@
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                          "bundled": true,
                           "dev": true
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                          "bundled": true,
                           "dev": true
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "ansi-regex": "2.0.0"
@@ -3771,16 +3719,14 @@
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "ansi-regex": "2.0.0"
@@ -3788,24 +3734,21 @@
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "commander": {
                       "version": "2.9.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "graceful-readlink": "1.0.1"
@@ -3813,16 +3756,14 @@
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.15.0",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-                      "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "generate-function": "2.0.0",
@@ -3833,14 +3774,12 @@
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                          "bundled": true,
                           "dev": true
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "is-property": "1.0.2"
@@ -3848,30 +3787,26 @@
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "4.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
-                          "integrity": "sha1-ZmHhYdL8RF8Z+YQwIxNDci4fy9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "xtend": {
                           "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "pinkie": "2.0.4"
@@ -3879,8 +3814,7 @@
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -3889,8 +3823,7 @@
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "boom": "2.10.1",
@@ -3901,8 +3834,7 @@
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "hoek": "2.16.3"
@@ -3910,8 +3842,7 @@
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "boom": "2.10.1"
@@ -3919,14 +3850,12 @@
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                      "bundled": true,
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "hoek": "2.16.3"
@@ -3936,8 +3865,7 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "assert-plus": "0.2.0",
@@ -3947,14 +3875,12 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "jsprim": {
                       "version": "1.3.1",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-                      "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "extsprintf": "1.0.2",
@@ -3964,20 +3890,17 @@
                       "dependencies": {
                         "extsprintf": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                          "bundled": true,
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                          "bundled": true,
                           "dev": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "extsprintf": "1.0.2"
@@ -3987,8 +3910,7 @@
                     },
                     "sshpk": {
                       "version": "1.10.1",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
-                      "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "asn1": "0.2.3",
@@ -4004,20 +3926,17 @@
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                          "bundled": true,
                           "dev": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                          "bundled": true,
                           "dev": true
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                          "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -4026,8 +3945,7 @@
                         },
                         "dashdash": {
                           "version": "1.14.0",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "assert-plus": "1.0.0"
@@ -4035,8 +3953,7 @@
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -4045,8 +3962,7 @@
                         },
                         "getpass": {
                           "version": "0.1.6",
-                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "assert-plus": "1.0.0"
@@ -4054,8 +3970,7 @@
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -4064,15 +3979,13 @@
                         },
                         "jsbn": {
                           "version": "0.1.0",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.3",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                          "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         }
@@ -4082,26 +3995,22 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                  "bundled": true,
                   "dev": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                  "bundled": true,
                   "dev": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                  "bundled": true,
                   "dev": true
                 },
                 "mime-types": {
                   "version": "2.1.12",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                  "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "mime-db": "1.24.0"
@@ -4109,40 +4018,34 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.24.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                      "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.7",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                  "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+                  "bundled": true,
                   "dev": true
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                  "bundled": true,
                   "dev": true
                 },
                 "qs": {
                   "version": "6.3.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-                  "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI=",
+                  "bundled": true,
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                  "bundled": true,
                   "dev": true
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "punycode": "1.4.1"
@@ -4150,24 +4053,21 @@
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "tunnel-agent": {
                   "version": "0.4.3",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                  "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "rimraf": {
               "version": "2.5.4",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob": "7.1.1"
@@ -4175,8 +4075,7 @@
               "dependencies": {
                 "glob": {
                   "version": "7.1.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                  "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "fs.realpath": "1.0.0",
@@ -4189,14 +4088,12 @@
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "inflight": {
                       "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "once": "1.4.0",
@@ -4205,22 +4102,19 @@
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "brace-expansion": "1.1.6"
@@ -4228,8 +4122,7 @@
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "balanced-match": "0.4.2",
@@ -4238,14 +4131,12 @@
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                              "bundled": true,
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -4254,8 +4145,7 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "wrappy": "1.0.2"
@@ -4263,16 +4153,14 @@
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -4281,14 +4169,12 @@
             },
             "semver": {
               "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+              "bundled": true,
               "dev": true
             },
             "tar": {
               "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "block-stream": "0.0.9",
@@ -4298,8 +4184,7 @@
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "inherits": "2.0.3"
@@ -4307,8 +4192,7 @@
                 },
                 "fstream": {
                   "version": "1.0.10",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-                  "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "graceful-fs": "4.1.9",
@@ -4319,24 +4203,21 @@
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.9",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-                      "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "tar-pack": {
               "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
-              "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "debug": "2.2.0",
@@ -4351,8 +4232,7 @@
               "dependencies": {
                 "debug": {
                   "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ms": "0.7.1"
@@ -4360,16 +4240,14 @@
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "fstream": {
                   "version": "1.0.10",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-                  "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "graceful-fs": "4.1.9",
@@ -4380,22 +4258,19 @@
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.9",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-                      "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                      "bundled": true,
                       "dev": true
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "fstream": "1.0.10",
@@ -4405,14 +4280,12 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "brace-expansion": "1.1.6"
@@ -4420,8 +4293,7 @@
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "balanced-match": "0.4.2",
@@ -4430,14 +4302,12 @@
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                              "bundled": true,
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -4448,8 +4318,7 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "wrappy": "1.0.2"
@@ -4457,16 +4326,14 @@
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "2.1.5",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                  "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "buffer-shims": "1.0.0",
@@ -4480,52 +4347,44 @@
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                      "bundled": true,
                       "dev": true
                     },
                     "core-util-is": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "bundled": true,
                       "dev": true
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "bundled": true,
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "bundled": true,
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "uid-number": {
                   "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-                  "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -4698,7 +4557,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@types/node": "6.0.41",
     "@types/reflect-metadata": "0.0.4",
-    "@types/sequelize": "4.0.60",
+    "@types/sequelize": "4.0.68",
     "es6-shim": "0.35.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "sinon": "1.17.7",
     "sinon-chai": "2.8.0",
     "source-map-support": "0.4.14",
-    "sqlite3": "3.1.9",
+    "sqlite3": "3.1.8",
     "ts-node": "3.0.4",
     "tslint": "4.3.1",
     "typescript": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -60,12 +60,11 @@
     "sinon": "1.17.7",
     "sinon-chai": "2.8.0",
     "source-map-support": "0.4.14",
-    "sqlite3": "3.1.8",
+    "sqlite3": "3.1.9",
     "ts-node": "3.0.4",
     "tslint": "4.3.1",
     "typescript": "2.2.1",
-    "uuid-validate": "0.0.2",
-    "sqlite3": "3.1.9"
+    "uuid-validate": "0.0.2"
   },
   "engines": {
     "node": ">=0.8.15"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "ts-node": "3.0.4",
     "tslint": "4.3.1",
     "typescript": "2.2.1",
-    "uuid-validate": "0.0.2"
+    "uuid-validate": "0.0.2",
+    "sqlite3": "3.1.9"
   },
   "engines": {
     "node": ">=0.8.15"


### PR DESCRIPTION
Sequelize is using Validator to validates UUID strings.
Validator supports 4 versions of UUID - 3,4,5 and all:
https://github.com/chriso/validator.js/blob/b59133b1727b6af355b403a9a97a19226cceb34b/lib/isUUID.js#L14-L19

This change is updating IsUUID to support all possible options - 3,4,5 and all.

see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/18777#issuecomment-321458784

**Other stuff**
Two additional changes:
1. `WhereOptions` --> `WhereOptions<any>` 
2. added `as IAssociationOptionsBelongsToMany`

I am not sure about any of those additional changes. I know it passed compilation and testing, but I basically choose the option that compiles. 

Also running `npm run build` before making any change failed.  I have upgraded to node 8 and then it passed. Is there any dependency on the node version or it was just something locally on my machine? 