### PR TITLE
support null value include in @Scopes 

### DIFF
--- a/lib/utils/object.ts
+++ b/lib/utils/object.ts
@@ -46,8 +46,10 @@ export function deepAssign(target: any, ...sources: any[]): any {
         } else if (sourceValue instanceof Date) {
 
           targetValue = new Date(sourceValue);
-        } else {
+        } else if (sourceValue === null) {
 
+          targetValue = null;
+        } else {
           deepAssign(targetValue, sourceValue);
         }
       } else {

--- a/test/models/ShoeWithScopes.ts
+++ b/test/models/ShoeWithScopes.ts
@@ -16,6 +16,9 @@ export const SHOE_SCOPES = {
   red: {
     where: {primaryColor: 'red'}
   },
+  noImg: {
+    where: {img: null}
+  },
   manufacturerWithScope: {
     include: [() => Manufacturer.scope('brandOnly')]
   },

--- a/test/specs/scopes.spec.ts
+++ b/test/specs/scopes.spec.ts
@@ -71,6 +71,11 @@ describe('scopes', () => {
 
           expect(yellowShoes).to.be.empty;
         })
+        .then(() => ShoeWithScopes.scope('noImg').findAll())
+        .then(noImgShoes => {
+
+          expect(noImgShoes).to.be.not.empty;
+        })
     );
 
     it('should not consider default scope due to unscoped call', () =>

--- a/test/specs/utils/object.spec.ts
+++ b/test/specs/utils/object.spec.ts
@@ -12,8 +12,8 @@ describe('utils', () => {
       const childSourceF = {};
       const childSourceA = {f: childSourceF};
       const childSourceB = {};
-      const source1 = {a: childSourceA, b: childSourceB, c: 1, d: 'd', over: 'ride', regex: /reg/gim};
-      const source2 = {e: 'für elisa', g: () => null, arr: [{h: 1}, {}, 'e'], over: 'ridden'};
+      const source1 = {a: childSourceA, b: childSourceB, c: 1, d: 'd', over: 'ride', regex: /reg/gim, notNull: null};
+      const source2 = {e: 'für elisa', g: () => null, arr: [{h: 1}, {}, 'e'], over: 'ridden', nullable: null, notNull: 'notNull'};
       const sourceKeys = [].concat(Object.keys(source1), Object.keys(source2));
 
       it('should not be undefined', () => {
@@ -61,7 +61,7 @@ describe('utils', () => {
         sourceKeys
           .forEach(key => {
 
-            if (typeof copy[key] === 'object') {
+            if (typeof copy[key] === 'object' && copy[key] !== null) {
 
               expect(copy[key]).not.to.equal(source1[key] || source2[key]);
               expect(copy[key]).to.eql(source1[key] || source2[key]);
@@ -99,6 +99,15 @@ describe('utils', () => {
           }
         });
       });
+
+      it('should have copy of nullable', () => {
+        const copy = deepAssign({}, source1, source2);
+
+        expect(copy.nullable).to.equals(null);
+        expect(copy.notNull).to.not.equals(null);
+
+      });
+
 
     });
 


### PR DESCRIPTION
I got error of below log and fixed it.
This error occurred by null value in `@Scopes`.

```log
/home/user/app/node_modules/sequelize-typescript/lib/utils/object.js:10
            .getOwnPropertyNames(source)
             ^
TypeError: Cannot convert undefined or null to object
    at Function.getOwnPropertyNames (<anonymous>)
    at /home/user/app/node_modules/sequelize-typescript/lib/utils/object.js:10:14
    at Array.forEach (native)
    at deepAssign (/home/user/app/node_modules/sequelize-typescript/lib/utils/object.js:8:13)
    at assign (/home/user/app/node_modules/sequelize-typescript/lib/utils/object.js:34:21)
    at /home/user/app/node_modules/sequelize-typescript/lib/utils/object.js:11:46
    at Array.forEach (native)
```

