### PR TITLE
When `IFindOptions.include = []` the `where` clause is ignored

### DIFF
--- a/lib/services/models.ts
+++ b/lib/services/models.ts
@@ -249,7 +249,7 @@ export function inferAlias(options: any, source: any): any {
     options.include = [options.include];
   } else if (!options.include.length) {
     delete options.include;
-    return;
+    return options;
   }
 
   // convert all included elements to { model: Model } form

--- a/test/specs/model.spec.ts
+++ b/test/specs/model.spec.ts
@@ -900,6 +900,36 @@ describe('model', () => {
           expect(u.username).to.equal('A fancy name');
         });
     });
+
+    it('should filter based on the where clause even if IFindOptions.include is []', () => {
+      @Table({paranoid: true, timestamps: true})
+      class User extends Model<User> {
+
+        @Column
+        username: string;
+      }
+      sequelize.addModels([User]);
+
+      return User.sync({force: true})
+        .then(() => {
+          return User.create({username: 'a1'});
+        })
+        .then(() => {
+          return User.create({username: 'a2'});
+        })
+        .then(() => {
+          return User.findOne<User>({where: {username: 'a2'}, include: []});
+        })
+        .then((u) => {
+          expect(u.username).to.equal('a2');
+        })
+        .then(() => {
+          return User.findOne<User>({where: {username: 'a1'}, include: []});
+        })
+        .then((u) => {
+          expect(u.username).to.equal('a1');
+        })
+    });
   });
 
   describe('findOrInitialize', () => {


### PR DESCRIPTION
```
A = Model.findOne({
   where: { attr1: "1", attr2: "2" },
   include: []
});

B = Model.findOne({
   where: { attr1: "1", attr2: "2" },
   include: undefined
};
```

Expect: A = B
Actual: A ignores the where clause and B doesn't.