### PR TITLE
tableName bug fix

### DIFF
--- a/lib/annotations/Table.ts
+++ b/lib/annotations/Table.ts
@@ -20,8 +20,6 @@ export function Table(arg: any): void|Function {
 
 function annotate(target: any, options: IDefineOptions = {}): void {
 
-  if (!options.tableName) options.tableName = target.name;
-
   options.instanceMethods = target.prototype;
   options.classMethods = target;
 


### PR DESCRIPTION
Setting tableName is unnecessary. It prevents to use underscoredAll option.