### PR TITLE
Add the hability to parse Glob and Folder path in modelPaths

### DIFF
--- a/test/models/globs/match-dir-only/PlayerDir.ts
+++ b/test/models/globs/match-dir-only/PlayerDir.ts
@@ -1,0 +1,7 @@
+import {Table, Model, Column,} from "../../../../index";
+
+@Table
+export default class PlayerDir extends Model<PlayerDir> {
+  @Column
+  name: string;
+}

--- a/test/models/globs/match-dir-only/ShoeDir.ts
+++ b/test/models/globs/match-dir-only/ShoeDir.ts
@@ -1,0 +1,9 @@
+import {Table, Model, Column} from "../../../../index";
+
+@Table
+export default class ShoeDir extends Model<ShoeDir> {
+
+  @Column
+  brand: string;
+
+}

--- a/test/models/globs/match-dir-only/TeamDir.ts
+++ b/test/models/globs/match-dir-only/TeamDir.ts
@@ -1,0 +1,8 @@
+import {Table, Model, Column} from "../../../../index";
+
+@Table
+export default class TeamDir extends Model<TeamDir> {
+
+  @Column
+  name: string;
+}

--- a/test/models/globs/match-sub-dir-files/players/player.model.ts
+++ b/test/models/globs/match-sub-dir-files/players/player.model.ts
@@ -1,0 +1,7 @@
+import {Table, Model, Column,} from "../../../../../index";
+
+@Table
+export default class PlayerGlob extends Model<PlayerGlob> {
+  @Column
+  name: string;
+}

--- a/test/models/globs/match-sub-dir-files/shoes/shoe.model.ts
+++ b/test/models/globs/match-sub-dir-files/shoes/shoe.model.ts
@@ -1,0 +1,9 @@
+import {Table, Model, Column} from "../../../../../index";
+
+@Table
+export default class ShoeGlob extends Model<ShoeGlob> {
+
+  @Column
+  brand: string;
+
+}

--- a/test/models/globs/match-sub-dir-files/teams/team.model.ts
+++ b/test/models/globs/match-sub-dir-files/teams/team.model.ts
@@ -1,0 +1,8 @@
+import {Table, Model, Column} from "../../../../../index";
+
+@Table
+export default class TeamGlob extends Model<TeamGlob> {
+
+  @Column
+  name: string;
+}

--- a/test/specs/models/sequelize.spec.ts
+++ b/test/specs/models/sequelize.spec.ts
@@ -7,6 +7,12 @@ import Gamer from "../../models/exports/gamer.model";
 import {Sequelize} from "../../../lib/models/Sequelize";
 import {Model} from '../../../lib/models/Model';
 import {Table} from '../../../lib/annotations/Table';
+import PlayerGlob from "../../models/globs/match-sub-dir-files/players/player.model";
+import ShoeGlob from "../../models/globs/match-sub-dir-files/shoes/shoe.model";
+import TeamGlob from "../../models/globs/match-sub-dir-files/teams/team.model";
+import PlayerDir from "../../models/globs/match-dir-only/PlayerDir";
+import TeamDir from "../../models/globs/match-dir-only/TeamDir";
+import ShoeDir from "../../models/globs/match-dir-only/ShoeDir";
 
 describe('sequelize', () => {
 
@@ -104,7 +110,7 @@ describe('sequelize', () => {
         .to.have.property('options')
         .that.has.property('define')
         .that.eqls(DEFINE_OPTIONS)
-      ;
+        ;
     });
 
     it('should set define options for models', () => {
@@ -187,5 +193,64 @@ describe('sequelize', () => {
       expect(sequelize._).to.have.property('Gamer', Gamer);
     });
 
+  });
+
+  describe('Add models as glob and dir', () => {
+    it('should load classes from subfolders matching glob criteria', () => {
+      const db = '__';
+      const sequelizeGlob = new Sequelize({
+        name: db,
+        dialect: 'sqlite',
+        username: 'root',
+        password: '',
+        storage: ':memory:',
+        logging: !('SEQ_SILENT' in process.env),
+        modelPaths: [__dirname + '/../../models/globs/match-sub-dir-files/**/*.model.ts']
+      });
+
+      expect(sequelizeGlob._).to.have.property('PlayerGlob', PlayerGlob);
+      expect(sequelizeGlob._).to.have.property('TeamGlob', TeamGlob);
+      expect(sequelizeGlob._).to.have.property('ShoeGlob', ShoeGlob);
+
+    });
+
+    it('should load classes from folders', () => {
+      const db = '__';
+      const sequelizeFolder = new Sequelize({
+        name: db,
+        dialect: 'sqlite',
+        username: 'root',
+        password: '',
+        storage: ':memory:',
+        logging: !('SEQ_SILENT' in process.env),
+        modelPaths: [__dirname + '/../../models/globs/match-dir-only']
+      });
+
+      expect(sequelizeFolder._).to.have.property('PlayerDir', PlayerDir);
+      expect(sequelizeFolder._).to.have.property('TeamDir', TeamDir);
+      expect(sequelizeFolder._).to.have.property('ShoeDir', ShoeDir);
+
+    });
+
+    it('should load classes from folders and from glob', () => {
+      const db = '__';
+      const sequelizeGlobFolder = new Sequelize({
+        name: db,
+        dialect: 'sqlite',
+        username: 'root',
+        password: '',
+        storage: ':memory:',
+        logging: !('SEQ_SILENT' in process.env),
+        modelPaths: [__dirname + '/../../models/globs/match-dir-only', __dirname + '/../../models/globs/match-sub-dir-files/**/*.model.ts']
+      });
+
+      expect(sequelizeGlobFolder._).to.have.property('PlayerDir', PlayerDir);
+      expect(sequelizeGlobFolder._).to.have.property('TeamDir', TeamDir);
+      expect(sequelizeGlobFolder._).to.have.property('ShoeDir', ShoeDir);
+      expect(sequelizeGlobFolder._).to.have.property('PlayerGlob', PlayerGlob);
+      expect(sequelizeGlobFolder._).to.have.property('TeamGlob', TeamGlob);
+      expect(sequelizeGlobFolder._).to.have.property('ShoeGlob', ShoeGlob);
+
+    });
   });
 });


### PR DESCRIPTION
Changed the usage of FS to GLOB. If the Path isn't a glob, it's a folder
path and to work with glob, must be turned into a glob (by adding /* in
the end).
I think the check if it `hasMagic` should be an outside function,
chained in a `map` before `arg.reduce`.