### PR TITLE
Type inference for static Model methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,10 +221,10 @@ export class User extends Model<User> {}
 ### Build and create
 Instantiation and inserts can be achieved in the good old sequelize way
 ```typescript
-const person = Person.build<Person>({name: 'bob', age: 99});
+const person = Person.build({name: 'bob', age: 99});
 person.save();
 
-Person.create<Person>({name: 'bob', age: 99});
+Person.create({name: 'bob', age: 99});
 ```
 but *sequelize-typescript* also makes it possible to create instances with `new`:
 ```typescript
@@ -237,7 +237,7 @@ Finding and updating entries does also work like using native sequelize. So see 
 [docs](http://docs.sequelizejs.com/manual/tutorial/models-usage.html) for more details.
 ```typescript
 Person
- .findOne<Person>()
+ .findOne()
  .then(person => {
      
      person.age = 100;
@@ -245,7 +245,7 @@ Person
  });
 
 Person
- .update<Person>({
+ .update({
    name: 'bobby'
  }, {where: {id: 1}})
  .then(() => {
@@ -290,7 +290,7 @@ That's all, *sequelize-typescript* does everything else for you. So when retriev
 ```typescript
 
 Team
- .findOne<Team>({include: [Player]})
+ .findOne({include: [Player]})
  .then(team => {
      
      team.players.forEach(player => console.log(`Player ${player.name}`));

--- a/lib/annotations/Column.ts
+++ b/lib/annotations/Column.ts
@@ -40,7 +40,7 @@ function annotate(target: any,
     };
   } else {
 
-    options = Object.assign({}, optionsOrDataType);
+    options = Object.assign({}, <IPartialDefineAttributeColumnOptions>optionsOrDataType);
 
     if (!options.type) {
       options.type = getSequelizeTypeByDesignType(target, propertyName);

--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -303,7 +303,7 @@ export declare abstract class Model<T> extends Hooks {
   /**
    * Builds a new model instance and calls save on it.
    */
-  static create<T extends Model<T>>(this: (new () => T), values?: T, options?: ICreateOptions): Promise<T>;
+  static create<T extends Model<T>>(this: (new () => T), values?: any, options?: ICreateOptions): Promise<T>;
   static create<T extends Model<T>, A>(this: (new () => T), values?: A, options?: ICreateOptions): Promise<T>;
   static create<A>(this: (new () => T), values?: A, options?: ICreateOptions): Promise<T>;
 

--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -57,7 +57,7 @@ export declare abstract class Model<T> extends Hooks {
    * @param schema The name of the schema
    * @param options
    */
-  static schema<T extends Model<T>>(schema: string, options?: SchemaOptions): Model<T>;
+  static schema<T extends Model<T>>(this: (new () => T), schema: string, options?: SchemaOptions): Model<T>;
 
   /**
    * Get the tablename of the model, taking schema into account. The method will return The name as a string
@@ -130,7 +130,7 @@ export declare abstract class Model<T> extends Hooks {
    * @return Model A reference to the model, with the scope(s) applied. Calling scope again on the returned
    *     model will clear the previous scope.
    */
-  static scope(options?: string | string[] | ScopeOptions | WhereOptions<any>): typeof Model;
+  static scope<T extends Model<T>>(this: (new () => T), options?: string | string[] | ScopeOptions | WhereOptions<any>): typeof T;
 
   /**
    * Search for multiple instances.
@@ -194,25 +194,25 @@ export declare abstract class Model<T> extends Hooks {
    *
    * @see    {Sequelize#query}
    */
-  static findAll<T extends Model<T>>(options?: IFindOptions<T>): Promise<T[]>;
+  static findAll<T extends Model<T>>(this: (new () => T), options?: IFindOptions<T>): Promise<T[]>;
 
-  static all<T extends Model<T>>(options?: IFindOptions<T>): Promise<T[]>;
+  static all<T extends Model<T>>(this: (new () => T), options?: IFindOptions<T>): Promise<T[]>;
 
   /**
    * Search for a single instance by its primary key. This applies LIMIT 1, so the listener will
    * always be called with a single instance.
    */
-  static findById<T extends Model<T>>(identifier?: number | string, options?: IFindOptions<T>): Promise<T | null>;
+  static findById<T extends Model<T>>(this: (new () => T), identifier?: number | string, options?: IFindOptions<T>): Promise<T | null>;
 
-  static findByPrimary<T extends Model<T>>(identifier?: number | string, options?: IFindOptions<T>): Promise<T | null>;
+  static findByPrimary<T extends Model<T>>(this: (new () => T), identifier?: number | string, options?: IFindOptions<T>): Promise<T | null>;
 
   /**
    * Search for a single instance. This applies LIMIT 1, so the listener will always be called with a single
    * instance.
    */
-  static findOne<T extends Model<T>>(options?: IFindOptions<T>): Promise<T | null>;
+  static findOne<T extends Model<T>>(this: (new () => T), options?: IFindOptions<T>): Promise<T | null>;
 
-  static find<T extends Model<T>>(options?: IFindOptions<T>): Promise<T | null>;
+  static find<T extends Model<T>>(this: (new () => T), options?: IFindOptions<T>): Promise<T | null>;
 
   /**
    * Run an aggregation method on the specified field
@@ -267,9 +267,9 @@ export declare abstract class Model<T> extends Hooks {
    * without
    * profiles will be counted
    */
-  static findAndCount<T extends Model<T>>(options?: IFindOptions<T>): Promise<{rows: T[], count: number}>;
+  static findAndCount<T extends Model<T>>(this: (new () => T), options?: IFindOptions<T>): Promise<{rows: T[], count: number}>;
 
-  static findAndCountAll<T extends Model<T>>(options?: IFindOptions<T>): Promise<{rows: T[], count: number}>;
+  static findAndCountAll<T extends Model<T>>(this: (new () => T), options?: IFindOptions<T>): Promise<{rows: T[], count: number}>;
 
   /**
    * Find the maximum value of field
@@ -289,30 +289,35 @@ export declare abstract class Model<T> extends Hooks {
   /**
    * Builds a new model instance. Values is an object of key value pairs, must be defined but can be empty.
    */
-  static build<T extends Model<T>>(record?: any, options?: IBuildOptions): T;
-  static build<T extends Model<T>, A>(record?: A, options?: IBuildOptions): T;
+  static build<T extends Model<T>>(this: (new () => T), record?: any, options?: IBuildOptions): T;
+  static build<T extends Model<T>, A>(this: (new () => T), record?: A, options?: IBuildOptions): T;
+  static build<A>(this: (new () => T), record?: A, options?: IBuildOptions): T;
 
   /**
    * Undocumented bulkBuild
    */
-  static bulkBuild<T extends Model<T>>(records: any[], options?: IBuildOptions): T[];
-  static bulkBuild<T extends Model<T>, A>(records: A[], options?: IBuildOptions): T[];
+  static bulkBuild<T extends Model<T>>(this: (new () => T), records: any[], options?: IBuildOptions): T[];
+  static bulkBuild<T extends Model<T>, A>(this: (new () => T), records: A[], options?: IBuildOptions): T[];
+  static bulkBuild<A>(this: (new () => T), records: A[], options?: IBuildOptions): T[];
 
   /**
    * Builds a new model instance and calls save on it.
    */
-  static create<T extends Model<T>>(values?: any, options?: ICreateOptions): Promise<T>;
-  static create<T extends Model<T>, A>(values?: A, options?: ICreateOptions): Promise<T>;
+  static create<T extends Model<T>>(this: (new () => T), values?: T, options?: ICreateOptions): Promise<T>;
+  static create<T extends Model<T>, A>(this: (new () => T), values?: A, options?: ICreateOptions): Promise<T>;
+  static create<A>(this: (new () => T), values?: A, options?: ICreateOptions): Promise<T>;
 
   /**
    * Find a row that matches the query, or build (but don't save) the row if none is found.
    * The successfull result of the promise will be (instance, initialized) - Make sure to use .spread()
    */
-  static findOrInitialize<T extends Model<T>>(options: IFindOrInitializeOptions<any>): Promise<[T, boolean]>;
-  static findOrInitialize<T extends Model<T>, A>(options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
+  static findOrInitialize<T extends Model<T>>(this: (new () => T), options: IFindOrInitializeOptions<any>): Promise<[T, boolean]>;
+  static findOrInitialize<T extends Model<T>, A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
+  static findOrInitialize<A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
 
-  static findOrBuild<T extends Model<T>>(options: IFindOrInitializeOptions<any>): Promise<[T, boolean]>;
-  static findOrBuild<T extends Model<T>, A>(options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
+  static findOrBuild<T extends Model<T>>(this: (new () => T), options: IFindOrInitializeOptions<any>): Promise<[T, boolean]>;
+  static findOrBuild<T extends Model<T>, A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
+  static findOrBuild<A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
 
   /**
    * Find a row that matches the query, or build and save the row if none is found
@@ -325,15 +330,17 @@ export declare abstract class Model<T> extends Hooks {
    * an instance of sequelize.TimeoutError will be thrown instead. If a transaction is created, a savepoint
    * will be created instead, and any unique constraint violation will be handled internally.
    */
-  static findOrCreate<T extends Model<T>>(options: IFindOrInitializeOptions<any>): Promise<[T, boolean]>;
-  static findOrCreate<T extends Model<T>, A>(options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
+  static findOrCreate<T extends Model<T>>(this: (new () => T), options: IFindOrInitializeOptions<any>): Promise<[T, boolean]>;
+  static findOrCreate<T extends Model<T>, A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
+  static findOrCreate<A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
 
   /**
    * A more performant findOrCreate that will not work under a transaction (at least not in postgres)
    * Will execute a find call, if empty then attempt to create, if unique constraint then attempt to find again
    */
-  static findCreateFind<T extends Model<T>>(options: IFindCreateFindOptions<any>): Promise<[T, boolean]>;
-  static findCreateFind<T extends Model<T>, A>(options: IFindCreateFindOptions<A>): Promise<[T, boolean]>;
+  static findCreateFind<T extends Model<T>>(this: (new () => T), options: IFindCreateFindOptions<any>): Promise<[T, boolean]>;
+  static findCreateFind<T extends Model<T>, A>(this: (new () => T), options: IFindCreateFindOptions<A>): Promise<[T, boolean]>;
+  static findCreateFind<A>(this: (new () => T), options: IFindCreateFindOptions<A>): Promise<[T, boolean]>;
 
   /**
    * Insert or update a single row. An update will be executed if a row which matches the supplied values on
@@ -369,8 +376,9 @@ export declare abstract class Model<T> extends Hooks {
    *
    * @param records List of objects (key/value pairs) to create instances from
    */
-  static bulkCreate<T extends Model<T>>(records: any[], options?: BulkCreateOptions): Promise<T[]>;
-  static bulkCreate<T extends Model<T>, A>(records: A[], options?: BulkCreateOptions): Promise<T[]>;
+  static bulkCreate<T extends Model<T>>(this: (new () => T), records: any[], options?: BulkCreateOptions): Promise<T[]>;
+  static bulkCreate<T extends Model<T>, A>(this: (new () => T), records: A[], options?: BulkCreateOptions): Promise<T[]>;
+  static bulkCreate<A>(this: (new () => T), records: A[], options?: BulkCreateOptions): Promise<T[]>;
 
   /**
    * Truncate all instances of the model. This is a convenient method for Model.destroy({ truncate: true }).
@@ -394,8 +402,9 @@ export declare abstract class Model<T> extends Hooks {
    * elements. The first element is always the number of affected rows, while the second element is the actual
    * affected rows (only supported in postgres with `options.returning` true.)
    */
-  static update<T extends Model<T>>(values: any, options: UpdateOptions): Promise<[number, Array<T>]>;
-  static update<T extends Model<T>, A>(values: A, options: UpdateOptions): Promise<[number, Array<T>]>;
+  static update<T extends Model<T>>(this: (new () => T), values: any, options: UpdateOptions): Promise<[number, Array<T>]>;
+  static update<T extends Model<T>, A>(this: (new () => T), values: A, options: UpdateOptions): Promise<[number, Array<T>]>;
+  static update<A>(this: (new () => T), values: A, options: UpdateOptions): Promise<[number, Array<T>]>;
 
   /**
    * Run a describe query on the table. The result will be return to the listener as a hash of attributes and
@@ -406,7 +415,7 @@ export declare abstract class Model<T> extends Hooks {
   /**
    * Unscope the model
    */
-  static unscoped(): typeof Model;
+  static unscoped<T extends Model<T>>(this: (new () => T)): typeof T;
 
   /**
    * A reference to the sequelize instance

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,11 +2,12 @@
   "name": "sequelize-typescript",
   "version": "0.6.0-beta.2",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha1-8SAWKwT9bVXhA0bX4ulu7UYrAs8="
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.18.tgz",
+      "integrity": "sha512-OTPWHmsyW18BhrnG5x8F7PzeZ2nFxmHGb42bZn79P9hl+GI5cMzyPgQTwNjbem0lJhoru/8vtjAFCUOu3+gE2w=="
     },
     "@types/chai": {
       "version": "3.4.35",
@@ -18,13 +19,20 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-0.0.29.tgz",
       "integrity": "sha1-Q9UokqqZjhhaPePiR37bhXO+HXc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/chai": "3.4.35",
+        "@types/promises-a-plus": "0.0.27"
+      }
     },
     "@types/chai-datetime": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/chai-datetime/-/chai-datetime-0.0.30.tgz",
       "integrity": "sha1-EhNEEGcsFkO9qlrKIzmw43F68Yg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/chai": "3.4.35"
+      }
     },
     "@types/lodash": {
       "version": "4.14.54",
@@ -62,7 +70,12 @@
     "@types/sequelize": {
       "version": "4.0.73",
       "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.0.73.tgz",
-      "integrity": "sha512-qfC8DDkU/ROyS5SudxKT80DU4F/YAFXSnlh0HdO7hIFOo5og2HDlOwEjAouRLNykUr6gscXC/C6+rlvxfiJp+g=="
+      "integrity": "sha512-qfC8DDkU/ROyS5SudxKT80DU4F/YAFXSnlh0HdO7hIFOo5og2HDlOwEjAouRLNykUr6gscXC/C6+rlvxfiJp+g==",
+      "requires": {
+        "@types/bluebird": "3.5.18",
+        "@types/lodash": "4.14.54",
+        "@types/validator": "6.2.2"
+      }
     },
     "@types/sinon": {
       "version": "1.16.35",
@@ -74,7 +87,11 @@
       "version": "2.7.27",
       "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.27.tgz",
       "integrity": "sha1-63cpBY3fJTppeeVZuytJEISWmqE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/chai": "3.4.35",
+        "@types/sinon": "1.16.35"
+      }
     },
     "@types/validator": {
       "version": "6.2.2",
@@ -85,7 +102,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
       "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -157,7 +177,12 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      }
     },
     "balanced-match": {
       "version": "0.4.2",
@@ -170,7 +195,10 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "bignumber.js": {
       "version": "3.1.2",
@@ -182,19 +210,37 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "boxen": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
       "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-align": "1.1.0",
+        "camelcase": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-boxes": "1.0.0",
+        "filled-array": "1.1.0",
+        "object-assign": "4.1.1",
+        "repeating": "2.0.1",
+        "string-width": "1.0.2",
+        "widest-line": "1.0.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
       "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -218,7 +264,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
       "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansicolors": "0.2.1",
+        "redeyed": "1.0.1"
+      }
     },
     "caseless": {
       "version": "0.11.0",
@@ -230,25 +280,43 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
     },
     "chai-as-promised": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
       "integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "check-error": "1.0.2"
+      }
     },
     "chai-datetime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/chai-datetime/-/chai-datetime-1.4.1.tgz",
       "integrity": "sha1-M3n8GNng0A8u1GWZh1JNYhHGQqg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chai": "3.5.0"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "check-error": {
       "version": "1.0.2",
@@ -272,7 +340,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/codecov/-/codecov-2.1.0.tgz",
       "integrity": "sha1-JfSPnpqnRzthxampNNWVQgpxyt4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argv": "0.0.2",
+        "request": "2.79.0",
+        "urlgrey": "0.4.4"
+      }
     },
     "colors": {
       "version": "1.1.2",
@@ -284,13 +357,19 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -303,6 +382,17 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
       "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
       "dev": true,
+      "requires": {
+        "dot-prop": "3.0.0",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "os-tmpdir": "1.0.2",
+        "osenv": "0.1.4",
+        "uuid": "2.0.3",
+        "write-file-atomic": "1.3.4",
+        "xdg-basedir": "2.0.0"
+      },
       "dependencies": {
         "uuid": {
           "version": "2.0.3",
@@ -322,19 +412,28 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -348,13 +447,19 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
     },
     "deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
@@ -392,13 +497,19 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
     },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
+      "requires": {
+        "readable-stream": "2.2.10"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -410,13 +521,25 @@
           "version": "2.2.10",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
           "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.0"
+          }
         }
       }
     },
@@ -425,13 +548,19 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "es6-shim": {
       "version": "0.35.3",
@@ -479,12 +608,22 @@
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
+      "requires": {
+        "glob": "5.0.15"
+      },
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
@@ -498,13 +637,21 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "formatio": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.2"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -522,13 +669,19 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -542,13 +695,38 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
       "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "got": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
       "dev": true,
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer2": "0.1.4",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "node-status-codes": "1.0.0",
+        "object-assign": "4.1.1",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.2.10",
+        "timed-out": "3.1.3",
+        "unzip-response": "1.0.2",
+        "url-parse-lax": "1.0.0"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -560,13 +738,25 @@
           "version": "2.2.10",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
           "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.0"
+          }
         }
       }
     },
@@ -592,13 +782,22 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.9.0",
+        "is-my-json-valid": "2.16.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
       "version": "2.0.0",
@@ -610,7 +809,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -622,7 +827,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.0",
+        "sshpk": "1.13.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.18",
@@ -640,7 +850,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -664,19 +878,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-npm": {
       "version": "1.0.0",
@@ -737,7 +963,10 @@
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "js-tokens": {
       "version": "3.0.1",
@@ -781,6 +1010,12 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -794,7 +1029,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
       "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "package-json": "2.4.0"
+      }
     },
     "lazy-req": {
       "version": "1.1.0",
@@ -812,7 +1050,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -842,7 +1084,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -860,7 +1107,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lolex": {
       "version": "1.3.2",
@@ -884,7 +1136,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "make-error": {
       "version": "1.3.0",
@@ -902,13 +1158,19 @@
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.7"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -920,19 +1182,38 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz",
       "integrity": "sha1-fcT0XlCIB1FxpoiWgU5q6et6heM=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.0.5",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
         "supports-color": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
@@ -952,13 +1233,32 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.13.0.tgz",
       "integrity": "sha1-mY8fjKRuLj3XFJzpgkE2U5hqrkc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bignumber.js": "3.1.2",
+        "readable-stream": "1.1.14",
+        "sqlstring": "2.2.0"
+      }
     },
     "mysql2": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-1.3.5.tgz",
       "integrity": "sha1-rmoJkiij3Ln5RUZ2B2/pOT1wrv4=",
       "dev": true,
+      "requires": {
+        "cardinal": "1.0.0",
+        "denque": "1.1.1",
+        "generate-function": "2.0.0",
+        "iconv-lite": "0.4.18",
+        "long": "3.2.0",
+        "lru-cache": "4.1.1",
+        "named-placeholders": "1.1.1",
+        "object-assign": "4.1.1",
+        "readable-stream": "2.2.11",
+        "safe-buffer": "5.1.0",
+        "seq-queue": "0.0.5",
+        "sqlstring": "2.2.0"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -971,6 +1271,15 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
           "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
           "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.0.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -984,7 +1293,10 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.0"
+          }
         }
       }
     },
@@ -993,6 +1305,9 @@
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.1.tgz",
       "integrity": "sha1-O3oNJiA910s6nfTJz7gnsvuQfmQ=",
       "dev": true,
+      "requires": {
+        "lru-cache": "2.5.0"
+      },
       "dependencies": {
         "lru-cache": {
           "version": "2.5.0",
@@ -1025,11 +1340,45 @@
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.2.tgz",
       "integrity": "sha512-31rRd6ME9NM17w0oPKqi51a6fzJAqYarnzQXK+iL8XaX+3H6VH0BQut7qHIgrv2mBASRic4oNi2KRgcbFODrsQ==",
       "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.0",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-hook": "1.0.7",
+        "istanbul-lib-instrument": "1.7.2",
+        "istanbul-lib-report": "1.1.1",
+        "istanbul-lib-source-maps": "1.2.1",
+        "istanbul-reports": "1.1.1",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.0.3",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.1",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.3.6",
+        "test-exclude": "4.1.1",
+        "yargs": "8.0.1",
+        "yargs-parser": "5.0.0"
+      },
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
         },
         "amdefine": {
           "version": "1.0.1",
@@ -1049,7 +1398,10 @@
         "append-transform": {
           "version": "0.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
         },
         "archy": {
           "version": "1.0.0",
@@ -1059,7 +1411,10 @@
         "arr-diff": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.0.3"
+          }
         },
         "arr-flatten": {
           "version": "1.0.3",
@@ -1084,37 +1439,83 @@
         "babel-code-frame": {
           "version": "6.22.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.1"
+          }
         },
         "babel-generator": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.6",
+            "trim-right": "1.0.1"
+          }
         },
         "babel-messages": {
           "version": "6.23.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
         },
         "babel-runtime": {
           "version": "6.23.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.10.5"
+          }
         },
         "babel-template": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.2",
+            "lodash": "4.17.4"
+          }
         },
         "babel-traverse": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.22.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.2",
+            "debug": "2.6.8",
+            "globals": "9.17.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
         },
         "babel-types": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
         },
         "babylon": {
           "version": "6.17.2",
@@ -1129,12 +1530,21 @@
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
         },
         "braces": {
           "version": "1.8.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
         },
         "builtin-modules": {
           "version": "1.1.1",
@@ -1144,24 +1554,45 @@
         "caching-transform": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          }
         },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
         },
         "chalk": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
@@ -1199,12 +1630,19 @@
         "cross-spawn": {
           "version": "4.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.0.2",
+            "which": "1.2.14"
+          }
         },
         "debug": {
           "version": "2.6.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "debug-log": {
           "version": "1.0.1",
@@ -1219,17 +1657,26 @@
         "default-require-extensions": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
         },
         "detect-indent": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
         },
         "error-ex": {
           "version": "1.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -1244,22 +1691,40 @@
         "execa": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "get-stream": "2.3.1",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
         },
         "expand-brackets": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
         },
         "expand-range": {
           "version": "1.8.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
         },
         "extglob": {
           "version": "0.3.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
         },
         "filename-regex": {
           "version": "2.0.1",
@@ -1269,17 +1734,32 @@
         "fill-range": {
           "version": "2.2.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.6",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
         },
         "find-cache-dir": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
         },
         "find-up": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
         },
         "for-in": {
           "version": "1.0.2",
@@ -1289,12 +1769,19 @@
         "for-own": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
         },
         "foreground-child": {
           "version": "1.5.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -1309,22 +1796,41 @@
         "get-stream": {
           "version": "2.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "glob-base": {
           "version": "0.3.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
         },
         "glob-parent": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
         },
         "globals": {
           "version": "9.17.0",
@@ -1340,18 +1846,30 @@
           "version": "4.0.10",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.27"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "has-flag": {
           "version": "1.0.0",
@@ -1371,7 +1889,11 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -1381,7 +1903,10 @@
         "invariant": {
           "version": "2.2.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
         },
         "invert-kv": {
           "version": "1.0.0",
@@ -1401,7 +1926,10 @@
         "is-builtin-module": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
         },
         "is-dotfile": {
           "version": "1.0.3",
@@ -1411,7 +1939,10 @@
         "is-equal-shallow": {
           "version": "0.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
         },
         "is-extendable": {
           "version": "0.1.1",
@@ -1426,22 +1957,34 @@
         "is-finite": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-glob": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
         },
         "is-number": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
         },
         "is-posix-bracket": {
           "version": "0.1.1",
@@ -1476,7 +2019,10 @@
         "isobject": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
         },
         "istanbul-lib-coverage": {
           "version": "1.1.1",
@@ -1486,34 +2032,65 @@
         "istanbul-lib-hook": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "append-transform": "0.4.0"
+          }
         },
         "istanbul-lib-instrument": {
           "version": "1.7.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.24.1",
+            "babel-template": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.2",
+            "istanbul-lib-coverage": "1.1.1",
+            "semver": "5.3.0"
+          }
         },
         "istanbul-lib-report": {
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
+          },
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
             }
           }
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debug": "2.6.8",
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "source-map": "0.5.6"
+          }
         },
         "istanbul-reports": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "handlebars": "4.0.10"
+          }
         },
         "js-tokens": {
           "version": "3.0.1",
@@ -1528,7 +2105,10 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
         },
         "lazy-cache": {
           "version": "1.0.4",
@@ -1539,17 +2119,31 @@
         "lcid": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
         },
         "load-json-file": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
         },
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          },
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
@@ -1571,17 +2165,27 @@
         "loose-envify": {
           "version": "1.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.1"
+          }
         },
         "lru-cache": {
           "version": "4.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
         },
         "md5-hex": {
           "version": "1.3.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
         },
         "md5-o-matic": {
           "version": "0.1.1",
@@ -1591,17 +2195,38 @@
         "mem": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
         },
         "merge-source-map": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.6"
+          }
         },
         "micromatch": {
           "version": "2.3.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
+          }
         },
         "mimic-fn": {
           "version": "1.1.0",
@@ -1611,7 +2236,10 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -1621,7 +2249,10 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -1631,17 +2262,29 @@
         "normalize-package-data": {
           "version": "2.3.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.4.2",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1"
+          }
         },
         "normalize-path": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.0.1"
+          }
         },
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -1656,17 +2299,28 @@
         "object.omit": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "optimist": {
           "version": "0.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -1676,7 +2330,12 @@
         "os-locale": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "execa": "0.5.1",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
         },
         "p-finally": {
           "version": "1.0.0",
@@ -1691,22 +2350,37 @@
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "p-limit": "1.1.0"
+          }
         },
         "parse-glob": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
         },
         "parse-json": {
           "version": "2.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
         },
         "path-exists": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -1726,7 +2400,12 @@
         "path-type": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "pify": {
           "version": "2.3.0",
@@ -1741,17 +2420,27 @@
         "pinkie-promise": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
         },
         "pkg-dir": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          },
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
             }
           }
         },
@@ -1768,22 +2457,39 @@
         "randomatic": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "kind-of": "3.2.2"
+          }
         },
         "read-pkg": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.3.8",
+            "path-type": "1.1.0"
+          }
         },
         "read-pkg-up": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          },
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
             }
           }
         },
@@ -1795,7 +2501,11 @@
         "regex-cache": {
           "version": "0.4.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3",
+            "is-primitive": "2.0.0"
+          }
         },
         "remove-trailing-separator": {
           "version": "1.0.1",
@@ -1815,7 +2525,10 @@
         "repeating": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
         },
         "require-directory": {
           "version": "2.1.1",
@@ -1836,12 +2549,18 @@
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "semver": {
           "version": "5.3.0",
@@ -1871,12 +2590,23 @@
         "spawn-wrap": {
           "version": "1.3.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.1",
+            "signal-exit": "3.0.2",
+            "which": "1.2.14"
+          }
         },
         "spdx-correct": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
@@ -1892,6 +2622,10 @@
           "version": "2.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "3.0.1"
+          },
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "2.0.0",
@@ -1903,12 +2637,18 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-bom": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
         },
         "strip-eof": {
           "version": "1.0.0",
@@ -1923,7 +2663,14 @@
         "test-exclude": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -1940,6 +2687,11 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "1.2.1",
@@ -1951,7 +2703,13 @@
               "version": "3.10.0",
               "bundled": true,
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
             }
           }
         },
@@ -1964,12 +2722,19 @@
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
         },
         "which": {
           "version": "1.2.14",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
         },
         "which-module": {
           "version": "2.0.0",
@@ -1991,11 +2756,20 @@
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
             }
           }
         },
@@ -2007,7 +2781,12 @@
         "write-file-atomic": {
           "version": "1.3.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
         },
         "y18n": {
           "version": "3.2.1",
@@ -2023,6 +2802,21 @@
           "version": "8.0.1",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.0.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.0.0",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
@@ -2033,33 +2827,61 @@
               "version": "3.2.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              },
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
                 }
               }
             },
             "load-json-file": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
+              }
             },
             "path-type": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "pify": "2.3.0"
+              }
             },
             "read-pkg": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.3.8",
+                "path-type": "2.0.0"
+              }
             },
             "read-pkg-up": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
+              }
             },
             "strip-bom": {
               "version": "3.0.0",
@@ -2069,7 +2891,10 @@
             "yargs-parser": {
               "version": "7.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
             }
           }
         },
@@ -2077,6 +2902,9 @@
           "version": "5.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
@@ -2103,13 +2931,20 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -2127,19 +2962,32 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "package-json": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
       "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "got": "5.7.1",
+        "registry-auth-token": "3.3.1",
+        "registry-url": "3.1.0",
+        "semver": "5.3.0"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2163,7 +3011,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -2176,6 +3027,10 @@
       "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
       "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
       "dev": true,
+      "requires": {
+        "colors": "1.1.2",
+        "minimist": "1.2.0"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -2214,6 +3069,12 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -2228,6 +3089,10 @@
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.2.10"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -2239,13 +3104,25 @@
           "version": "2.2.10",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
           "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.0"
+          }
         }
       }
     },
@@ -2253,13 +3130,22 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
     },
     "redeyed": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esprima": "3.0.0"
+      }
     },
     "reflect-metadata": {
       "version": "0.1.9",
@@ -2271,31 +3157,66 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "rc": "1.2.1",
+        "safe-buffer": "5.1.0"
+      }
     },
     "registry-url": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "rc": "1.2.1"
+      }
     },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "request": {
       "version": "2.79.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.0.1"
+      }
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "safe-buffer": {
       "version": "5.1.0",
@@ -2319,7 +3240,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "semver": "5.3.0"
+      }
     },
     "seq-queue": {
       "version": "0.0.5",
@@ -2331,7 +3255,13 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
+      }
     },
     "sinon-chai": {
       "version": "2.8.0",
@@ -2349,7 +3279,10 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "source-map": {
       "version": "0.5.6",
@@ -2361,7 +3294,10 @@
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
       "integrity": "sha1-nURjdyWYuGJxtPUj9sH04Cp9au8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
     },
     "sprintf-js": {
       "version": "1.1.1",
@@ -2374,16 +3310,34 @@
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.8.tgz",
       "integrity": "sha1-TLz5Zdi5AdGxAVy8f8QVquFX36o=",
       "dev": true,
+      "requires": {
+        "nan": "2.4.0",
+        "node-pre-gyp": "0.6.31"
+      },
       "dependencies": {
         "node-pre-gyp": {
           "version": "0.6.31",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.0.0",
+            "rc": "1.1.6",
+            "request": "2.76.0",
+            "rimraf": "2.5.4",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.3.0"
+          },
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
@@ -2396,6 +3350,9 @@
               "version": "3.0.6",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "abbrev": "1.0.9"
+              },
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.9",
@@ -2408,11 +3365,21 @@
               "version": "4.0.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "are-we-there-yet": "1.1.2",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.6.0",
+                "set-blocking": "2.0.0"
+              },
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.1.5"
+                  },
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
@@ -2423,6 +3390,15 @@
                       "version": "2.1.5",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                      },
                       "dependencies": {
                         "buffer-shims": {
                           "version": "1.0.0",
@@ -2472,6 +3448,17 @@
                   "version": "2.6.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "aproba": "1.0.4",
+                    "console-control-strings": "1.1.0",
+                    "has-color": "0.1.7",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.0",
+                    "signal-exit": "3.0.1",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.0"
+                  },
                   "dependencies": {
                     "aproba": {
                       "version": "1.0.4",
@@ -2502,11 +3489,19 @@
                       "version": "1.0.2",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "code-point-at": "1.0.1",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.0.1",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -2519,6 +3514,9 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -2533,6 +3531,9 @@
                       "version": "3.0.1",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
@@ -2544,7 +3545,10 @@
                     "wide-align": {
                       "version": "1.1.0",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
                     }
                   }
                 },
@@ -2559,6 +3563,12 @@
               "version": "1.1.6",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "deep-extend": "0.4.1",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "1.0.4"
+              },
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.1",
@@ -2586,6 +3596,28 @@
               "version": "2.76.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.5.0",
+                "caseless": "0.11.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.0",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.1",
+                "har-validator": "2.0.6",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.12",
+                "node-uuid": "1.4.7",
+                "oauth-sign": "0.8.2",
+                "qs": "6.3.0",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.4.3"
+              },
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
@@ -2606,6 +3638,9 @@
                   "version": "1.0.5",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
@@ -2628,6 +3663,11 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.12"
+                  },
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
@@ -2640,11 +3680,24 @@
                   "version": "2.0.6",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "commander": "2.9.0",
+                    "is-my-json-valid": "2.15.0",
+                    "pinkie-promise": "2.0.1"
+                  },
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                      },
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
@@ -2660,6 +3713,9 @@
                           "version": "2.0.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
@@ -2672,6 +3728,9 @@
                           "version": "3.0.1",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
@@ -2691,6 +3750,9 @@
                       "version": "2.9.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "graceful-readlink": "1.0.1"
+                      },
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
@@ -2703,6 +3765,12 @@
                       "version": "2.15.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.2.0",
+                        "jsonpointer": "4.0.0",
+                        "xtend": "4.0.1"
+                      },
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
@@ -2713,6 +3781,9 @@
                           "version": "1.2.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "is-property": "1.0.2"
+                          },
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
@@ -2737,6 +3808,9 @@
                       "version": "2.0.1",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
@@ -2751,16 +3825,28 @@
                   "version": "3.1.3",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
                     },
                     "cryptiles": {
                       "version": "2.0.5",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
                     },
                     "hoek": {
                       "version": "2.16.3",
@@ -2770,7 +3856,10 @@
                     "sntp": {
                       "version": "1.0.9",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
                     }
                   }
                 },
@@ -2778,6 +3867,11 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.3.1",
+                    "sshpk": "1.10.1"
+                  },
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
@@ -2788,6 +3882,11 @@
                       "version": "1.3.1",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                      },
                       "dependencies": {
                         "extsprintf": {
                           "version": "1.0.2",
@@ -2802,7 +3901,10 @@
                         "verror": {
                           "version": "1.3.6",
                           "bundled": true,
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
                         }
                       }
                     },
@@ -2810,6 +3912,17 @@
                       "version": "1.10.1",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.0",
+                        "dashdash": "1.14.0",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.6",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.0",
+                        "tweetnacl": "0.14.3"
+                      },
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
@@ -2825,29 +3938,44 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "dev": true,
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "tweetnacl": "0.14.3"
+                          }
                         },
                         "dashdash": {
                           "version": "1.14.0",
                           "bundled": true,
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
                           "bundled": true,
                           "dev": true,
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
                         },
                         "getpass": {
                           "version": "0.1.6",
                           "bundled": true,
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
                         },
                         "jodid25519": {
                           "version": "1.0.2",
                           "bundled": true,
                           "dev": true,
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
                         },
                         "jsbn": {
                           "version": "0.1.0",
@@ -2884,6 +4012,9 @@
                   "version": "2.1.12",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "mime-db": "1.24.0"
+                  },
                   "dependencies": {
                     "mime-db": {
                       "version": "1.24.0",
@@ -2916,6 +4047,9 @@
                   "version": "2.3.2",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  },
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
@@ -2935,11 +4069,22 @@
               "version": "2.5.4",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "glob": "7.1.1"
+              },
               "dependencies": {
                 "glob": {
                   "version": "7.1.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.3",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  },
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
@@ -2950,6 +4095,10 @@
                       "version": "1.0.6",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
@@ -2967,11 +4116,18 @@
                       "version": "3.0.3",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "brace-expansion": "1.1.6"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
@@ -2991,6 +4147,9 @@
                       "version": "1.4.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
@@ -3017,16 +4176,30 @@
               "version": "2.2.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.10",
+                "inherits": "2.0.3"
+              },
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
                 },
                 "fstream": {
                   "version": "1.0.10",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.9",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.5.4"
+                  },
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.9",
@@ -3046,11 +4219,24 @@
               "version": "3.3.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "debug": "2.2.0",
+                "fstream": "1.0.10",
+                "fstream-ignore": "1.0.5",
+                "once": "1.3.3",
+                "readable-stream": "2.1.5",
+                "rimraf": "2.5.4",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              },
               "dependencies": {
                 "debug": {
                   "version": "2.2.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "ms": "0.7.1"
+                  },
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
@@ -3063,6 +4249,12 @@
                   "version": "1.0.10",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.9",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.5.4"
+                  },
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.9",
@@ -3080,6 +4272,11 @@
                   "version": "1.0.5",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "fstream": "1.0.10",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.3"
+                  },
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
@@ -3090,11 +4287,18 @@
                       "version": "3.0.3",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "brace-expansion": "1.1.6"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
@@ -3116,6 +4320,9 @@
                   "version": "1.3.3",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
@@ -3128,6 +4335,15 @@
                   "version": "2.1.5",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "buffer-shims": "1.0.0",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
@@ -3188,6 +4404,17 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
       "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
       "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jodid25519": "1.0.2",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3197,16 +4424,21 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "stringstream": {
@@ -3219,7 +4451,10 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -3249,13 +4484,28 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "ts-node": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.0.4.tgz",
       "integrity": "sha1-oUdevyT9Ti7i+6ixqhYFuXe95QY=",
       "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "chalk": "1.1.3",
+        "diff": "3.2.0",
+        "make-error": "1.3.0",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.14",
+        "tsconfig": "6.0.0",
+        "v8flags": "2.1.1",
+        "yn": "1.3.0"
+      },
       "dependencies": {
         "diff": {
           "version": "3.2.0",
@@ -3275,13 +4525,28 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
       "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1"
+      }
     },
     "tslint": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.3.1.tgz",
       "integrity": "sha1-KPZ5xTyksnNoi8tvzw3ef/G7IWk=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "colors": "1.1.2",
+        "diff": "3.2.0",
+        "findup-sync": "0.3.0",
+        "glob": "7.1.2",
+        "optimist": "0.6.1",
+        "resolve": "1.3.3",
+        "underscore.string": "3.3.4",
+        "update-notifier": "1.0.3"
+      },
       "dependencies": {
         "diff": {
           "version": "3.2.0",
@@ -3293,7 +4558,15 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
@@ -3317,16 +4590,20 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz",
-      "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
       "dev": true
     },
     "underscore.string": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
     },
     "unzip-response": {
       "version": "1.0.2",
@@ -3338,13 +4615,26 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
       "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boxen": "0.6.0",
+        "chalk": "1.1.3",
+        "configstore": "2.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "2.0.0",
+        "lazy-req": "1.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "2.0.0"
+      }
     },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
     },
     "urlgrey": {
       "version": "0.4.4",
@@ -3363,6 +4653,9 @@
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -3394,19 +4687,28 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
     },
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "widest-line": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -3424,13 +4726,21 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
+      }
     },
     "xdg-basedir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
       "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "xtend": {
       "version": "4.0.1",
@@ -3448,7 +4758,10 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-1.3.0.tgz",
       "integrity": "sha1-GwgSq7jYBdSJZvjfOF3J2syaGdg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,105 +1,105 @@
 {
-  "name": "sequelize-typescript",
-  "version": "0.6.0-beta.2",
-  "description": "Decorators and some other extras for sequelize (v3 + v4)",
-  "scripts": {
-    "build": "tsc --project lib/models/v4 && tsc",
-    "build-tests-es5": "tsc --project test",
-    "build-tests-es6": "tsc --project test --target es6 && tsc",
-    "prepare-test-v3": "npm install sequelize@3.30.4 --no-save && npm run build-tests-es5",
-    "prepare-test-v4": "npm install sequelize@4.1.0 --no-save && npm run build-tests-es6",
-    "test-v3": "npm run prepare-test-v3 && npm run exec-tests",
-    "test-v4": "npm run prepare-test-v4 && npm run exec-tests",
-    "cover-v3": "npm run prepare-test-v3 && nyc --exclude lib/models/v4/**/*.js --all --require source-map-support/register mocha test/specs/",
-    "cover-v4": "npm run prepare-test-v4 && nyc --exclude lib/models/v3/**/*.js --all --require source-map-support/register mocha test/specs/",
-    "exec-tests": "mocha test/specs/",
-    "test": "npm run test-v4 && npm run test-v3",
-    "cover": "npm run cover-v4 && npm run cover-v3",
-    "lint": "tslint ."
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/RobinBuschmann/sequelize-typescript.git"
-  },
-  "keywords": [
-    "orm",
-    "object relational mapper",
-    "sequelize",
-    "typescript",
-    "decorators",
-    "mysql",
-    "sqlite",
-    "postgresql",
-    "postgres",
-    "mssql"
-  ],
-  "author": "Robin Buschmann",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/RobinBuschmann/sequelize-typescript/issues"
-  },
-  "homepage": "https://github.com/RobinBuschmann/sequelize-typescript#readme",
-  "main": "index.js",
-  "types": "index.d.ts",
-  "dependencies": {
-    "@types/bluebird": "3.5.4",
-    "@types/node": "6.0.41",
-    "@types/reflect-metadata": "0.0.4",
-    "@types/sequelize": "4.0.73",
-    "es6-shim": "0.35.3"
-  },
-  "devDependencies": {
-    "@types/chai": "3.4.35",
-    "@types/chai-as-promised": "0.0.29",
-    "@types/chai-datetime": "0.0.30",
-    "@types/lodash": "4.14.54",
-    "@types/mocha": "2.2.39",
-    "@types/prettyjson": "0.0.28",
-    "@types/sinon": "1.16.35",
-    "@types/sinon-chai": "2.7.27",
-    "chai": "3.5.0",
-    "chai-as-promised": "6.0.0",
-    "chai-datetime": "1.4.1",
-    "codecov": "2.1.0",
-    "has-flag": "2.0.0",
-    "lodash": "4.17.4",
-    "mocha": "3.2.0",
-    "moment": "2.17.1",
-    "mysql": "2.13.0",
-    "mysql2": "1.3.5",
-    "nyc": "11.0.2",
-    "prettyjson": "1.2.1",
-    "reflect-metadata": "0.1.9",
-    "sinon": "1.17.7",
-    "sinon-chai": "2.8.0",
-    "source-map-support": "0.4.14",
-    "sqlite3": "3.1.8",
-    "ts-node": "3.0.4",
-    "tslint": "4.3.1",
-    "typescript": "2.2.1",
-    "uuid-validate": "0.0.2"
-  },
-  "engines": {
-    "node": ">=0.8.15"
-  },
-  "nyc": {
-    "lines": 85,
-    "statements": 85,
-    "functions": 85,
-    "branches": 85,
-    "include": [
-      "lib/**/*.js"
+    "name": "sequelize-typescript",
+    "version": "0.6.0-beta.2",
+    "description": "Decorators and some other extras for sequelize (v3 + v4)",
+    "scripts": {
+        "build": "tsc --project lib/models/v4 && tsc",
+        "build-tests-es5": "tsc --project test",
+        "build-tests-es6": "tsc --project test --target es6 && tsc",
+        "prepare-test-v3": "npm install sequelize@3.30.4 --no-save && npm run build-tests-es5",
+        "prepare-test-v4": "npm install sequelize@4.22.1 --no-save && npm run build-tests-es6",
+        "test-v3": "npm run prepare-test-v3 && npm run exec-tests",
+        "test-v4": "npm run prepare-test-v4 && npm run exec-tests",
+        "cover-v3": "npm run prepare-test-v3 && nyc --exclude lib/models/v4/**/*.js --all --require source-map-support/register mocha test/specs/",
+        "cover-v4": "npm run prepare-test-v4 && nyc --exclude lib/models/v3/**/*.js --all --require source-map-support/register mocha test/specs/",
+        "exec-tests": "mocha test/specs/",
+        "test": "npm run test-v4 && npm run test-v3",
+        "cover": "npm run cover-v4 && npm run cover-v3",
+        "lint": "tslint ."
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/RobinBuschmann/sequelize-typescript.git"
+    },
+    "keywords": [
+        "orm",
+        "object relational mapper",
+        "sequelize",
+        "typescript",
+        "decorators",
+        "mysql",
+        "sqlite",
+        "postgresql",
+        "postgres",
+        "mssql"
     ],
-    "exclude": [
-      "test/**/*.js"
-    ],
-    "reporter": [
-      "lcov",
-      "text-summary"
-    ],
-    "cache": true,
-    "all": true,
-    "check-coverage": true,
-    "report-dir": "./coverage"
-  }
+    "author": "Robin Buschmann",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/RobinBuschmann/sequelize-typescript/issues"
+    },
+    "homepage": "https://github.com/RobinBuschmann/sequelize-typescript#readme",
+    "main": "index.js",
+    "types": "index.d.ts",
+    "dependencies": {
+        "@types/bluebird": "3.5.18",
+        "@types/node": "6.0.41",
+        "@types/reflect-metadata": "0.0.4",
+        "@types/sequelize": "4.0.73",
+        "es6-shim": "0.35.3"
+    },
+    "devDependencies": {
+        "@types/chai": "3.4.35",
+        "@types/chai-as-promised": "0.0.29",
+        "@types/chai-datetime": "0.0.30",
+        "@types/lodash": "4.14.54",
+        "@types/mocha": "2.2.39",
+        "@types/prettyjson": "0.0.28",
+        "@types/sinon": "1.16.35",
+        "@types/sinon-chai": "2.7.27",
+        "chai": "3.5.0",
+        "chai-as-promised": "6.0.0",
+        "chai-datetime": "1.4.1",
+        "codecov": "2.1.0",
+        "has-flag": "2.0.0",
+        "lodash": "4.17.4",
+        "mocha": "3.2.0",
+        "moment": "2.17.1",
+        "mysql": "2.13.0",
+        "mysql2": "1.3.5",
+        "nyc": "11.0.2",
+        "prettyjson": "1.2.1",
+        "reflect-metadata": "0.1.9",
+        "sinon": "1.17.7",
+        "sinon-chai": "2.8.0",
+        "source-map-support": "0.4.14",
+        "sqlite3": "3.1.8",
+        "ts-node": "3.0.4",
+        "tslint": "4.3.1",
+        "typescript": "~2.5.3",
+        "uuid-validate": "0.0.2"
+    },
+    "engines": {
+        "node": ">=0.8.15"
+    },
+    "nyc": {
+        "lines": 85,
+        "statements": 85,
+        "functions": 85,
+        "branches": 85,
+        "include": [
+            "lib/**/*.js"
+        ],
+        "exclude": [
+            "test/**/*.js"
+        ],
+        "reporter": [
+            "lcov",
+            "text-summary"
+        ],
+        "cache": true,
+        "all": true,
+        "check-coverage": true,
+        "report-dir": "./coverage"
+    }
 }

--- a/test/specs/instance-methods.spec.ts
+++ b/test/specs/instance-methods.spec.ts
@@ -35,9 +35,9 @@ describe('instance-methods', () => {
   beforeEach(() => sequelize.sync({force: true}));
 
   const suites: Array<[string, () => Promise<User>]> = [
-    ['build', () => Promise.resolve<User>(User.build<User>({firstName: 'Peter', lastName: 'Parker'}))],
+    ['build', () => Promise.resolve<User>(User.build({firstName: 'Peter', lastName: 'Parker'}))],
     ['new', () => Promise.resolve<User>(new User({firstName: 'Peter', lastName: 'Parker'}))],
-    ['create', () => (User.create<User>({firstName: 'Peter', lastName: 'Parker'}))],
+    ['create', () => (User.create({firstName: 'Peter', lastName: 'Parker'}))],
   ];
 
   suites.forEach(([name, create]) => {
@@ -86,7 +86,7 @@ describe('instance-methods', () => {
 
           return user
             .save()
-            .then(() => User.findById<User>(user.id))
+            .then(() => User.findById(user.id))
             .then(_user => {
 
               expect(_user.firstName).to.equal(firstName);

--- a/test/specs/instance.spec.ts
+++ b/test/specs/instance.spec.ts
@@ -23,6 +23,7 @@ import {UserWithCreatedAtButWithoutUpdatedAt} from "../models/UserWithCreatedAtB
 import {UserWithVersion} from "../models/UserWithVersion";
 import chaiDatetime = require('chai-datetime');
 import {IDefineOptions} from "../../lib/interfaces/IDefineOptions";
+import * as Promise from 'bluebird';
 // import {UserWithSwag} from "../models/UserWithSwag";
 
 // TODO@robin create belongs to many with through options "add" test
@@ -44,11 +45,11 @@ describe('instance', () => {
 
     beforeEach(() =>
       Promise.all([
-        Book.create<Book>({
+        Book.create({
           title: 'Crime and Punishment',
           pages: [{content: 'A'}]
         }, {include: [Page]}),
-        Book.create<Book>({
+        Book.create({
           title: 'The Brothers Karamazov',
           pages: [{content: 'B'}, {content: 'C'}]
         }, {include: [Page]})
@@ -79,7 +80,7 @@ describe('instance', () => {
 
     it('should return true for include values of found instance', () =>
       Book
-        .findOne<Book>({include: [Page]})
+        .findOne({include: [Page]})
         .then(book => {
 
           book.pages.forEach(page => {
@@ -94,14 +95,14 @@ describe('instance', () => {
   describe('isNewRecord', () => {
 
     it('returns true for non-saved objects', () => {
-      const user = User.build<User>({username: 'user'});
+      const user = User.build({username: 'user'});
       expect(user.id).to.be.null;
       expect(user.isNewRecord).to.be.ok;
     });
 
     it('returns false for saved objects', () =>
       User
-        .build<User>({username: 'user'})
+        .build({username: 'user'})
         .save()
         .then((user) => {
           expect(user.isNewRecord).to.not.be.ok;
@@ -110,8 +111,8 @@ describe('instance', () => {
 
     it('returns false for created objects', () =>
       User
-        .create<User>({username: 'user'})
-        .then((user: User) => {
+        .create({username: 'user'})
+        .then((user) => {
           expect(user.id).to.not.be.null;
           expect(user.isNewRecord).to.not.be.ok;
         })
@@ -122,10 +123,10 @@ describe('instance', () => {
         .create({username: 'user'})
         .then(() =>
           User
-            .create<User>({username: 'user'})
+            .create({username: 'user'})
             .then((user) =>
               User
-                .findById<User>(user.id)
+                .findById(user.id)
                 .then((_user) => {
                   expect(_user).to.not.be.null;
                   expect(_user && _user.isNewRecord).to.not.be.ok;
@@ -145,7 +146,7 @@ describe('instance', () => {
         .bulkCreate(users)
         .then(() =>
           User
-            .findAll<User>()
+            .findAll()
             .then((_users) => {
               _users.forEach((u) => {
                 expect(u.isNewRecord).to.not.be.ok;
@@ -178,7 +179,7 @@ describe('instance', () => {
     //                   .then((users1) =>
     //
     //                     User
-    //                       .findAll<User>({transaction})
+    //                       .findAll({transaction})
     //                       .then((users2) => {
     //
     //                         // expect(users1[0].aNumber).to.equal(0); TODO check
@@ -197,7 +198,7 @@ describe('instance', () => {
 
       it('supports returning', () =>
         User
-          .findById<User>(1)
+          .findById(1)
           .then((user1) => {
 
             if (user1) {
@@ -213,7 +214,7 @@ describe('instance', () => {
 
     it('supports where conditions', () =>
       User
-        .findById<User>(1)
+        .findById(1)
         .then((user1) => {
 
             if (user1) {
@@ -221,7 +222,7 @@ describe('instance', () => {
               return user1.increment(['aNumber'], {by: 2, where: {bNumber: 1}})
                 .then(() =>
                   User
-                    .findById<User>(1)
+                    .findById(1)
                     .then((user3) => {
                       expect(user3.aNumber).to.be.equal(0);
                     })
@@ -233,12 +234,12 @@ describe('instance', () => {
 
     it('with array', () =>
       User
-        .findById<User>(1)
+        .findById(1)
         .then((user1) =>
           user1.increment(['aNumber'], {by: 2})
             .then(() =>
               User
-                .findById<User>(1)
+                .findById(1)
                 .then((user3) => {
                   expect(user3.aNumber).to.be.equal(2);
                 })
@@ -248,13 +249,13 @@ describe('instance', () => {
 
     it('with single field', () =>
       User
-        .findById<User>(1)
+        .findById(1)
         .then((user1) =>
           user1
             .increment('aNumber', {by: 2})
             .then(() =>
               User
-                .findById<User>(1)
+                .findById(1)
                 .then((user3) => {
                   expect(user3.aNumber).to.be.equal(2);
                 })
@@ -264,12 +265,12 @@ describe('instance', () => {
 
     it('with single field and no value', () =>
       User
-        .findById<User>(1)
+        .findById(1)
         .then((user1) =>
           user1.increment('aNumber')
             .then(() =>
               User
-                .findById<User>(1)
+                .findById(1)
                 .then((user2) => {
                   expect(user2.aNumber).to.be.equal(1);
                 })
@@ -279,11 +280,11 @@ describe('instance', () => {
 
     it('should still work right with other concurrent updates', () =>
       User
-        .findById<User>(1)
+        .findById(1)
         .then((user1) =>
           // Select the user again (simulating a concurrent query)
           User
-            .findById<User>(1)
+            .findById(1)
             .then((user2) =>
               user2
                 .updateAttributes({
@@ -294,7 +295,7 @@ describe('instance', () => {
                     .increment(['aNumber'], {by: 2})
                     .then(() =>
                       User
-                        .findById<User>(1)
+                        .findById(1)
                         .then((user5) => {
                           expect(user5.aNumber).to.be.equal(3);
                         })
@@ -306,7 +307,7 @@ describe('instance', () => {
 
     it('should still work right with other concurrent increments', () =>
       User
-        .findById<User>(1)
+        .findById(1)
         .then((user1) =>
           sequelize.Promise.all([
             user1.increment(['aNumber'], {by: 2}),
@@ -315,7 +316,7 @@ describe('instance', () => {
           ])
             .then(() =>
               User
-                .findById<User>(1)
+                .findById(1)
                 .then((user2) => {
                   expect(user2.aNumber).to.equal(6);
                 })
@@ -325,13 +326,13 @@ describe('instance', () => {
 
     it('with key value pair', () =>
       User
-        .findById<User>(1)
+        .findById(1)
         .then((user1) =>
           user1
             .increment({aNumber: 1, bNumber: 2})
             .then(() =>
               User
-                .findById<User>(1)
+                .findById(1)
                 .then((user3) => {
                   expect(user3.aNumber).to.be.equal(1);
                   expect(user3.bNumber).to.be.equal(2);
@@ -347,7 +348,7 @@ describe('instance', () => {
 
       return TimeStampsUser
         .sync({force: true})
-        .then(() => TimeStampsUser.create<TimeStampsUser>({aNumber: 1}))
+        .then(() => TimeStampsUser.create({aNumber: 1}))
         .then((user) => {
 
           oldDate = user.updatedAt;
@@ -356,7 +357,7 @@ describe('instance', () => {
 
           return user.increment('aNumber', {by: 1});
         })
-        .then(() => TimeStampsUser.findById<TimeStampsUser>(1))
+        .then(() => TimeStampsUser.findById(1))
         .then(user => {
           expect(user).to.have.property('updatedAt');
           expect(user.updatedAt).to.be.greaterThan(oldDate);
@@ -369,14 +370,14 @@ describe('instance', () => {
 
       return TimeStampsUser
         .sync({force: true})
-        .then(() => TimeStampsUser.create<TimeStampsUser>({aNumber: 1}))
+        .then(() => TimeStampsUser.create({aNumber: 1}))
         .then((user) => {
 
           oldDate = user.updatedAt;
 
           return user.increment('aNumber', {by: 1, silent: true});
         })
-        .then(() => TimeStampsUser.findById<TimeStampsUser>(1))
+        .then(() => TimeStampsUser.findById(1))
         .then(user => {
           expect(user).to.have.property('updatedAt');
           expect(user.updatedAt).to.eqls(oldDate);
@@ -391,7 +392,7 @@ describe('instance', () => {
     //
     //   it('supports transactions', () =>
     //     User
-    //       .create<User>({aNumber: 3})
+    //       .create({aNumber: 3})
     //       .then((user) =>
     //         sequelize
     //           .transaction()
@@ -403,7 +404,7 @@ describe('instance', () => {
     //                   .findAll()
     //                   .then((users1) =>
     //                     User
-    //                       .findAll<User>({transaction})
+    //                       .findAll({transaction})
     //                       .then((users2) => {
     //                         // expect(users1[0].aNumber).to.equal(3); // TODO transactions does not seem to work
     //                         expect(users2[0].aNumber).to.equal(1);
@@ -418,14 +419,14 @@ describe('instance', () => {
 
     it('with array', () =>
       User
-        .create<User>({aNumber: 0})
-        .then(() => User.findById<User>(1))
+        .create({aNumber: 0})
+        .then(() => User.findById(1))
         .then((user1) =>
           user1
             .decrement(['aNumber'], {by: 2})
             .then(() =>
               User
-                .findById<User>(1)
+                .findById(1)
                 .then((user3) => {
                   expect(user3.aNumber).to.be.equal(-2);
                 })
@@ -435,14 +436,14 @@ describe('instance', () => {
 
     it('with single field', () =>
       User
-        .create<User>({aNumber: 0})
-        .then(() => User.findById<User>(1))
+        .create({aNumber: 0})
+        .then(() => User.findById(1))
         .then((user1) =>
           user1
             .decrement('aNumber', {by: 2})
             .then(() =>
               User
-                .findById<User>(1)
+                .findById(1)
                 .then((user3) => {
                   expect(user3.aNumber).to.be.equal(-2);
                 })
@@ -452,14 +453,14 @@ describe('instance', () => {
 
     it('with single field and no value', () =>
       User
-        .create<User>({aNumber: 0})
-        .then(() => User.findById<User>(1))
+        .create({aNumber: 0})
+        .then(() => User.findById(1))
         .then((user1) =>
           user1
             .decrement('aNumber')
             .then(() =>
               User
-                .findById<User>(1)
+                .findById(1)
                 .then((user2) => {
                   expect(user2.aNumber).to.be.equal(-1);
                 })
@@ -469,12 +470,12 @@ describe('instance', () => {
 
     it('should still work right with other concurrent updates', () =>
       User
-        .create<User>({aNumber: 0})
-        .then(() => User.findById<User>(1))
+        .create({aNumber: 0})
+        .then(() => User.findById(1))
         .then((user1) =>
           // Select the user again (simulating a concurrent query)
           User
-            .findById<User>(1)
+            .findById(1)
             .then((user2) =>
               user2
                 .updateAttributes({
@@ -485,7 +486,7 @@ describe('instance', () => {
                     .decrement(['aNumber'], {by: 2})
                     .then(() =>
                       User
-                        .findById<User>(1)
+                        .findById(1)
                         .then((user5) => {
                           expect(user5.aNumber).to.be.equal(-1);
                         })
@@ -497,8 +498,8 @@ describe('instance', () => {
 
     it('should still work right with other concurrent increments', () =>
       User
-        .create<User>({aNumber: 0})
-        .then(() => User.findById<User>(1))
+        .create({aNumber: 0})
+        .then(() => User.findById(1))
         .then((user1) =>
           sequelize.Promise.all([
             user1.decrement(['aNumber'], {by: 2}),
@@ -507,7 +508,7 @@ describe('instance', () => {
           ])
             .then(() =>
               User
-                .findById<User>(1)
+                .findById(1)
                 .then((user2) => {
                   expect(user2.aNumber).to.equal(-6);
                 })
@@ -517,14 +518,14 @@ describe('instance', () => {
 
     it('with key value pair', () =>
       User
-        .create<User>({aNumber: 0, bNumber: 0})
-        .then(() => User.findById<User>(1))
+        .create({aNumber: 0, bNumber: 0})
+        .then(() => User.findById(1))
         .then((user1) =>
           user1
             .decrement({aNumber: 1, bNumber: 2})
             .then(() =>
               User
-                .findById<User>(1)
+                .findById(1)
                 .then((user3) => {
                   expect(user3.aNumber).to.be.equal(-1);
                   expect(user3.bNumber).to.be.equal(-2);
@@ -540,7 +541,7 @@ describe('instance', () => {
 
       return TimeStampsUser
         .sync({force: true})
-        .then(() => TimeStampsUser.create<TimeStampsUser>({aNumber: 1}))
+        .then(() => TimeStampsUser.create({aNumber: 1}))
         .then((user) => {
           oldDate = user.updatedAt;
 
@@ -548,7 +549,7 @@ describe('instance', () => {
 
           return user.decrement('aNumber', {by: 1});
         })
-        .then(() => TimeStampsUser.findById<TimeStampsUser>(1))
+        .then(() => TimeStampsUser.findById(1))
         .then(user => {
           expect(user).to.have.property('updatedAt');
           expect(user.updatedAt).to.be.greaterThan(oldDate);
@@ -561,12 +562,12 @@ describe('instance', () => {
 
       return TimeStampsUser
         .sync({force: true})
-        .then(() => TimeStampsUser.create<TimeStampsUser>({aNumber: 1}))
+        .then(() => TimeStampsUser.create({aNumber: 1}))
         .then((user) => {
           oldDate = user.updatedAt;
           return user.decrement('aNumber', {by: 1, silent: true});
         })
-        .then(() => TimeStampsUser.findById<TimeStampsUser>(1))
+        .then(() => TimeStampsUser.findById(1))
         .then(user => {
           expect(user).to.have.property('updatedAt');
           expect(user.updatedAt).to.eqls(oldDate);
@@ -585,13 +586,13 @@ describe('instance', () => {
     //       .sync({force: true})
     //       .then(() =>
     //         User
-    //           .create<User>({username: 'foo'})
+    //           .create({username: 'foo'})
     //           .then((user) =>
     //             sequelize
     //               .transaction()
     //               .then((transaction) =>
     //                 User
-    //                   .update<User>({username: 'bar'}, {where: {username: 'foo'}, transaction})
+    //                   .update({username: 'bar'}, {where: {username: 'foo'}, transaction})
     //                   .then(() =>
     //                     user
     //                       .reload()
@@ -613,7 +614,7 @@ describe('instance', () => {
 
     it('should return a reference to the same DAO instead of creating a new one', () =>
       User
-        .create<User>({username: 'John Doe'})
+        .create({username: 'John Doe'})
         .then((originalUser) =>
           originalUser
             .updateAttributes({username: 'Doe John'})
@@ -629,10 +630,10 @@ describe('instance', () => {
 
     it('should update the values on all references to the DAO', () =>
       User
-        .create<User>({username: 'John Doe'})
+        .create({username: 'John Doe'})
         .then((originalUser) =>
           User
-            .findById<User>(originalUser.id)
+            .findById(originalUser.id)
             .then((updater) =>
               updater
                 .updateAttributes({username: 'Doe John'})
@@ -650,8 +651,8 @@ describe('instance', () => {
 
     it('should support updating a subset of attributes', () =>
       User
-        .create<User>({aNumber: 1, bNumber: 1})
-        .tap((user) => User.update<User>({bNumber: 2}, {where: {id: user.get('id')}}))
+        .create({aNumber: 1, bNumber: 1})
+        .tap((user) => User.update({bNumber: 2}, {where: {id: user.get('id')}}))
         .then((user) => user.reload({attributes: ['bNumber']}))
         .then((user) => {
           expect(user.get('aNumber')).to.equal(1);
@@ -665,12 +666,12 @@ describe('instance', () => {
       let _updatedUser;
 
       return TimeStampsUser
-        .create<TimeStampsUser>({username: 'John Doe'})
+        .create({username: 'John Doe'})
         .then((originalUser) => {
           originallyUpdatedAt = originalUser.updatedAt;
           _originalUser = originalUser;
 
-          return TimeStampsUser.findById<TimeStampsUser>(originalUser.id);
+          return TimeStampsUser.findById(originalUser.id);
         })
         .then((updater) => updater.updateAttributes({username: 'Doe John'}))
         .then((updatedUser) => {
@@ -687,10 +688,10 @@ describe('instance', () => {
       Book
         .sync({force: true})
         .then(() => Page.sync({force: true}))
-        .then(() => Book.create<Book>({title: 'A very old book'}))
+        .then(() => Book.create({title: 'A very old book'}))
         .then((book) =>
           Page
-            .create<Page>({content: 'om nom nom'})
+            .create({content: 'om nom nom'})
             .then((page) =>
               book
                 .$set('pages', [page])
@@ -720,15 +721,15 @@ describe('instance', () => {
       Book
         .sync({force: true})
         .then(() => Page.sync({force: true}))
-        .then(() => Book.create<Book>({title: 'A very old book'}))
+        .then(() => Book.create({title: 'A very old book'}))
         .then((book) =>
           Page
-            .create<Page>()
+            .create()
             .then((page) =>
               book['setPages']([page]) // todo
                 .then(() =>
                   Book
-                    .findOne<Book>({where: {id: book.id}})
+                    .findOne({where: {id: book.id}})
                     .then((leBook) => {
                       return leBook.reload({include: [Page]})
                         .then((_leBook: Book) => {
@@ -743,7 +744,7 @@ describe('instance', () => {
 
     it('should return an error when reload fails', () =>
       User
-        .create<User>({username: 'John Doe'})
+        .create({username: 'John Doe'})
         .then((user) =>
           user
             .destroy()
@@ -783,7 +784,7 @@ describe('instance', () => {
 
     it('should set an association to empty after all deletion, 1-N', () =>
       Team
-        .create<Team>({
+        .create({
           name: 'the team',
           players: [{
             name: 'the player1'
@@ -815,7 +816,7 @@ describe('instance', () => {
 
     it('should update the associations after one element deleted', () =>
       Team
-        .create<Team, {name: string; players: Array<{name: string}>}>({
+        .create<{name: string; players: Array<{name: string}>}>({
           name: 'the team',
           players: [{
             name: 'the player1'
@@ -825,7 +826,7 @@ describe('instance', () => {
         }, {include: [Player]})
         .then((team) =>
           Team
-            .findOne<Team>({
+            .findOne({
               where: {id: team.id},
               include: [Player]
             })
@@ -846,25 +847,25 @@ describe('instance', () => {
     describe('uuid', () => {
 
       it('should store a string in uuidv1 and uuidv4', () => {
-        const user = User.build<User>({username: 'a user'});
+        const user = User.build({username: 'a user'});
         expect(user.uuidv1).to.be.a('string');
         expect(user.uuidv4).to.be.a('string');
       });
 
       it('should store a string of length 36 in uuidv1 and uuidv4', () => {
-        const user = User.build<User>({username: 'a user'});
+        const user = User.build({username: 'a user'});
         expect(user.uuidv1).to.have.length(36);
         expect(user.uuidv4).to.have.length(36);
       });
 
       it('should store a valid uuid in uuidv1 and uuidv4 that conforms to the UUID v1 and v4 specifications', () => {
-        const user = User.build<User>({username: 'a user'});
+        const user = User.build({username: 'a user'});
         expect(validateUUID(user.uuidv1, 1)).to.be.true;
         expect(validateUUID(user.uuidv4, 4)).to.be.true;
       });
 
       it('should store a valid uuid if the field is a primary key named id', () => {
-        const person = Person.build<Person>({});
+        const person = Person.build({});
         expect(person.id).to.be.ok;
         expect(person.id).to.have.length(36);
       });
@@ -874,14 +875,14 @@ describe('instance', () => {
     describe('current date', () => {
 
       it('should store a date in touchedAt', () => {
-        const user = User.build<User>({username: 'a user'});
+        const user = User.build({username: 'a user'});
         expect(user.touchedAt).to.be.instanceof(Date);
       });
 
       it('should store the current date in touchedAt', () => {
         const clock = useFakeTimers();
         clock.tick(5000);
-        const user = User.build<User>({username: 'a user'});
+        const user = User.build({username: 'a user'});
         clock.restore();
         expect(+user.touchedAt).to.be.equal(5000);
       });
@@ -891,11 +892,11 @@ describe('instance', () => {
 
       it('should be just "null" and not Date with Invalid Date', () =>
         User
-          .build<User>({username: 'a user'})
+          .build({username: 'a user'})
           .save()
           .then(() =>
             User
-              .findOne<User>({where: {username: 'a user'}})
+              .findOne({where: {username: 'a user'}})
               .then((user) => {
                 expect(user.dateAllowNullTrue).to.be.null;
               })
@@ -906,11 +907,11 @@ describe('instance', () => {
 
         const date = new Date();
         return User
-          .build<User>({username: 'a user', dateAllowNullTrue: date})
+          .build({username: 'a user', dateAllowNullTrue: date})
           .save()
           .then(() =>
             User
-              .findOne<User>({where: {username: 'a user'}})
+              .findOne({where: {username: 'a user'}})
               .then((user) => {
                 expect(user.dateAllowNullTrue.toString()).to.equal(date.toString());
               })
@@ -922,12 +923,12 @@ describe('instance', () => {
 
       it('should default to false', () =>
         User
-          .build<User>({
+          .build({
             username: 'a user'
           })
           .save()
           .then(() =>
-            User.findOne<User>({
+            User.findOne({
               where: {
                 username: 'a user'
               }
@@ -939,13 +940,13 @@ describe('instance', () => {
 
       it('should override default when given truthy boolean', () =>
         User
-          .build<User>({
+          .build({
             username: 'a user',
             isSuperUser: true
           })
           .save()
           .then(() => {
-            User.findOne<User>({
+            User.findOne({
               where: {
                 username: 'a user'
               }
@@ -958,13 +959,13 @@ describe('instance', () => {
 
       it('should override default when given truthy boolean-string ("true")', () =>
         User
-          .build<User>({
+          .build({
             username: 'a user',
             isSuperUser: "true" as any // by intention
           })
           .save()
           .then(() => {
-            User.findOne<User>({
+            User.findOne({
               where: {
                 username: 'a user'
               }
@@ -977,13 +978,13 @@ describe('instance', () => {
 
       it('should override default when given truthy boolean-int (1)', () =>
         User
-          .build<User>({
+          .build({
             username: 'a user',
             isSuperUser: 1
           })
           .save()
           .then(() => {
-            User.findOne<User>({
+            User.findOne({
               where: {
                 username: 'a user'
               }
@@ -998,7 +999,7 @@ describe('instance', () => {
         let callCount = 0;
 
         return User
-          .build<User>({
+          .build({
             username: 'a user',
             isSuperUser: "INCORRECT_VALUE_TYPE" as any // incorrect value by intention
           })
@@ -1017,7 +1018,7 @@ describe('instance', () => {
 
     it('gets triggered if an error occurs', () =>
       User
-        .findOne({where: ['asdasdasd']})
+        .findOne({where: <any>['asdasdasd']})
         .catch((err) => {
           expect(err).to.exist;
           expect(err.message).to.exist;
@@ -1044,7 +1045,7 @@ describe('instance', () => {
     //       .then(() => sequelize.transaction())
     //       .then((transaction) =>
     //         User
-    //           .build<User>({username: 'foo'})
+    //           .build({username: 'foo'})
     //           .save({transaction})
     //           .then(() => User.count())
     //           .then((count1) =>
@@ -1065,7 +1066,7 @@ describe('instance', () => {
       const date = new Date(1990, 1, 1);
 
       return User
-        .create<User>({
+        .create({
           username: 'foo',
           touchedAt: new Date()
         })
@@ -1076,7 +1077,7 @@ describe('instance', () => {
           return user
             .save({fields: ['username']})
             // re-select user
-            .then(() => User.findById<User>(user.id))
+            .then(() => User.findById(user.id))
             .then((user2) => {
               // name should have changed
               expect(user2.username).to.equal('fizz');
@@ -1103,7 +1104,7 @@ describe('instance', () => {
 
     it('only validates fields in passed array', () =>
       User
-        .build<User>({
+        .build({
           validateTest: 'cake', // invalid, but not saved
           validateCustom: '1'
         })
@@ -1122,9 +1123,9 @@ describe('instance', () => {
 
         return User
           .sync({force: true})
-          .then(() => User.create<User>({name: 'A', bio: 'A', email: 'A'}))
+          .then(() => User.create({name: 'A', bio: 'A', email: 'A'}))
           .then((user) => user.set({name: 'B', bio: 'B'}).save())
-          .then(() => User.findOne<User>({}))
+          .then(() => User.findOne({}))
           .then((user) => {
             expect(user.get('name')).to.equal('B');
             expect(user.get('bio')).to.equal('B');
@@ -1140,9 +1141,9 @@ describe('instance', () => {
 
         return User
           .sync({force: true})
-          .then(() => User.create<User>({name: 'A', bio: 'A', email: 'A'}))
+          .then(() => User.create({name: 'A', bio: 'A', email: 'A'}))
           .then((user: User) => user.set({name: 'B', bio: 'B', email: 'B'}).save())
-          .then(() => User.findOne<User>({}))
+          .then(() => User.findOne({}))
           .then((user) => {
             expect(user.get('name')).to.equal('B');
             expect(user.get('bio')).to.equal('B');
@@ -1157,7 +1158,7 @@ describe('instance', () => {
 
         return UserWithValidation
           .sync({force: true})
-          .then(() => UserWithValidation.create<UserWithValidation>({
+          .then(() => UserWithValidation.create({
             name: 'A',
             bio: 'A',
             email: 'valid.email@gmail.com'
@@ -1167,7 +1168,7 @@ describe('instance', () => {
               name: 'B'
             }).save()).to.be.rejectedWith(Sequelize.ValidationError)
           )
-          .then(() => UserWithValidation.findOne<UserWithValidation>({}))
+          .then(() => UserWithValidation.findOne({}))
           .then((user) => {
             expect(user.get('email')).to.equal('valid.email@gmail.com');
           });
@@ -1181,7 +1182,7 @@ describe('instance', () => {
 
         return UserWithValidation
           .sync({force: true})
-          .then(() => UserWithValidation.create<UserWithValidation>({
+          .then(() => UserWithValidation.create({
             name: 'A',
             bio: 'A',
             email: 'valid.email@gmail.com'
@@ -1192,7 +1193,7 @@ describe('instance', () => {
               email: 'still.valid.email@gmail.com'
             }).save()).to.be.rejectedWith(Sequelize.ValidationError)
           )
-          .then(() => UserWithValidation.findOne<UserWithValidation>({}))
+          .then(() => UserWithValidation.findOne({}))
           .then((user) => {
             expect(user.get('email')).to.equal('valid.email@gmail.com');
           });
@@ -1202,7 +1203,7 @@ describe('instance', () => {
 
     it('stores an entry in the database', () => {
       const username = 'user';
-      const user = User.build<User>({
+      const user = User.build({
         username,
         touchedAt: new Date(1984, 8, 23)
       });
@@ -1213,7 +1214,7 @@ describe('instance', () => {
 
           return user.save();
         })
-        .then(() => User.findAll<User>())
+        .then(() => User.findAll())
         .then((users) => {
 
           expect(users).to.have.length(1);
@@ -1228,14 +1229,14 @@ describe('instance', () => {
       const username = 'user';
       const newUsername = 'newUser';
 
-      return UserWithNoAutoIncrementation.create<UserWithNoAutoIncrementation>({id: 0, username})
+      return UserWithNoAutoIncrementation.create({id: 0, username})
         .then((user) => {
 
           expect(user).to.be.ok;
           expect(user.id).to.equal(0);
           expect(user.username).to.equal(username);
         })
-        .then(() => UserWithNoAutoIncrementation.findById<UserWithNoAutoIncrementation>(0))
+        .then(() => UserWithNoAutoIncrementation.findById(0))
         .then((user) => {
 
           expect(user).to.be.ok;
@@ -1256,7 +1257,7 @@ describe('instance', () => {
       const clock = useFakeTimers();
       const now = new Date();
 
-      const user = TimeStampsUser.build<TimeStampsUser>({username: 'user'});
+      const user = TimeStampsUser.build({username: 'user'});
 
       clock.tick(1000);
 
@@ -1274,7 +1275,7 @@ describe('instance', () => {
       const clock = useFakeTimers();
 
       return TimeStampsUser
-        .create<TimeStampsUser>({username: 'user'})
+        .create({username: 'user'})
         .then((user) => {
 
           const updatedAt = user.updatedAt;
@@ -1301,8 +1302,8 @@ describe('instance', () => {
       ];
 
       return TimeStampsUser
-        .bulkCreate<TimeStampsUser>(data)
-        .then(() => TimeStampsUser.findAll<TimeStampsUser>())
+        .bulkCreate(data)
+        .then(() => TimeStampsUser.findAll())
         .then((users) => {
           updatedAtPaul = users[0].updatedAt;
           updatedAtPeter = users[1].updatedAt;
@@ -1317,7 +1318,7 @@ describe('instance', () => {
               {where: {}, silent: true}
             );
         })
-        .then(() => TimeStampsUser.findAll<TimeStampsUser>())
+        .then(() => TimeStampsUser.findAll())
         .then((users) => {
           expect(users[0].updatedAt).to.equalTime(updatedAtPeter);
           expect(users[1].updatedAt).to.equalTime(updatedAtPaul);
@@ -1335,7 +1336,7 @@ describe('instance', () => {
       it('does not update timestamps', () =>
         TimeStampsUser
           .create({username: 'John'})
-          .then(() => TimeStampsUser.findOne<TimeStampsUser>({where: {username: 'John'}}))
+          .then(() => TimeStampsUser.findOne({where: {username: 'John'}}))
           .then((user) => {
 
             const updatedAt = user.updatedAt;
@@ -1348,7 +1349,7 @@ describe('instance', () => {
                 expect(newlySavedUser.updatedAt).to.equalTime(updatedAt);
 
                 return TimeStampsUser
-                  .findOne<TimeStampsUser>({where: {username: 'John'}})
+                  .findOne({where: {username: 'John'}})
                   .then((_newlySavedUser) => {
 
                     expect(_newlySavedUser.updatedAt).to.equalTime(updatedAt);
@@ -1367,14 +1368,14 @@ describe('instance', () => {
       // it('should not throw ER_EMPTY_QUERY if changed only virtual fields', () =>
       //   UserWithSwag
       //     .sync({force: true})
-      //     .then(() => UserWithSwag.create<UserWithSwag>({name: 'John', bio: 'swag 1'}))
+      //     .then(() => UserWithSwag.create({name: 'John', bio: 'swag 1'}))
       //     .then((user) => expect(user.update({bio: 'swag 2'})).to.be.fulfilled)
       // );
     });
 
     it('updates with function and column value', () =>
       User
-        .create<User>({
+        .create({
           aNumber: 42
         })
         .then((user) => {
@@ -1384,7 +1385,7 @@ describe('instance', () => {
 
           return user
             .save()
-            .then(() => User.findById<User>(user.id))
+            .then(() => User.findById(user.id))
             .then((user2) => {
               expect(user2.username).to.equal('SEQUELIZE');
               expect(user2.bNumber).to.equal(42);
@@ -1397,7 +1398,7 @@ describe('instance', () => {
       it("doesn't update the updatedAt column", () =>
         UserWithCustomUpdatedAt
           .sync()
-          .then(() => UserWithCustomUpdatedAt.create<UserWithCustomUpdatedAt>({username: 'john doe'}))
+          .then(() => UserWithCustomUpdatedAt.create({username: 'john doe'}))
           .then((johnDoe) => {
             // sqlite and mysql return undefined, whereas postgres returns null
             expect([undefined, null].indexOf(johnDoe.updatedAt)).not.to.be.equal(-1);
@@ -1415,7 +1416,7 @@ describe('instance', () => {
         UserWithCreatedAtButWithoutUpdatedAt
           .sync()
           .then(() => UserWithCreatedAtButWithoutUpdatedAt
-            .create<UserWithCreatedAtButWithoutUpdatedAt>({username: 'john doe'}))
+            .create({username: 'john doe'}))
           .then((johnDoe) => {
             expect(johnDoe).not.to.have.property('updatedAt');
             expect(now).to.be.beforeTime(johnDoe.createdAt);
@@ -1441,7 +1442,7 @@ describe('instance', () => {
         sequelize.addModels([User2]);
 
         return User2.sync()
-          .then(() => User2.create<User2>({username: 'john doe'}))
+          .then(() => User2.create({username: 'john doe'}))
           .then((johnDoe) => {
 
             expect(johnDoe.createdAt).to.be.undefined;
@@ -1473,7 +1474,7 @@ describe('instance', () => {
 
         return User3
           .sync()
-          .then(() => User3.create<User3>({username: 'john doe'}))
+          .then(() => User3.create({username: 'john doe'}))
           .then((johnDoe) => {
             expect(johnDoe.createdAt).to.be.an.instanceof(Date);
             expect(!isNaN(johnDoe.createdAt.valueOf())).to.be.ok;
@@ -1489,7 +1490,7 @@ describe('instance', () => {
         let version = undefined;
           UserWithCustomUpdatedAt
             .sync()
-            .then(() => UserWithVersion.create<UserWithVersion>({ name: 'john doe' }))
+            .then(() => UserWithVersion.create({ name: 'john doe' }))
             .then((johnDoe: UserWithVersion) => {
               expect(johnDoe.version).not.to.be.undefined;
               version = johnDoe.version;
@@ -1531,7 +1532,7 @@ describe('instance', () => {
 
     it('should fail a validation upon building', () =>
       User
-        .build<User>({aNumber: 0, validateCustom: 'aaaaaaaaaaaaaaaaaaaaaaaaaa'})
+        .build({aNumber: 0, validateCustom: 'aaaaaaaaaaaaaaaaaaaaaaaaaa'})
         .save()
         .catch((err) => {
           expect(err).to.exist;
@@ -1545,7 +1546,7 @@ describe('instance', () => {
 
     it('should fail a validation when updating', () =>
       User
-        .create<User>({aNumber: 0})
+        .create({aNumber: 0})
         .then((user) => user.updateAttributes({validateTest: 'hello'}))
         .catch((err) => {
           expect(err).to.exist;
@@ -1559,7 +1560,7 @@ describe('instance', () => {
 
     it('takes zero into account', () =>
       User
-        .build<User>({aNumber: 0})
+        .build({aNumber: 0})
         .save({fields: ['aNumber']})
         .then((user) => {
           expect(user.aNumber).to.equal(0);
@@ -1584,7 +1585,7 @@ describe('instance', () => {
 
       return HistoryLog
         .sync()
-        .then(() => HistoryLog.create<HistoryLog>({someText: 'Some random text', aNumber: 3, aRandomId: 5}))
+        .then(() => HistoryLog.create({someText: 'Some random text', aNumber: 3, aRandomId: 5}))
         .then((log) => log.updateAttributes({aNumber: 5}))
         .then((newLog) => {
           expect(newLog.aNumber).to.equal(5);
@@ -1629,11 +1630,11 @@ describe('instance', () => {
 
       it('saves one object that has a collection of eagerly loaded objects', () =>
         UserEager
-          .create<UserEager>({username: 'joe', age: 1})
-          .then((user) => ProjectEager.create<ProjectEager>({title: 'project-joe1', overdueDays: 0})
-            .then((project1) => ProjectEager.create<ProjectEager>({title: 'project-joe2', overdueDays: 0})
+          .create({username: 'joe', age: 1})
+          .then((user) => ProjectEager.create({title: 'project-joe1', overdueDays: 0})
+            .then((project1) => ProjectEager.create({title: 'project-joe2', overdueDays: 0})
               .then((project2) => user.$set('projects', [project1, project2]))
-              .then(() => UserEager.findOne<UserEager>({where: {age: 1}, include: [ProjectEager]}))
+              .then(() => UserEager.findOne({where: {age: 1}, include: [ProjectEager]}))
               .then((_user) => {
                 expect(_user.username).to.equal('joe');
                 expect(_user.age).to.equal(1);
@@ -1656,21 +1657,21 @@ describe('instance', () => {
       it('saves many objects that each a have collection of eagerly loaded objects', () =>
 
         Promise
-          .all([
-            UserEager.create({username: 'bart', age: 20}),
-            UserEager.create({username: 'lisa', age: 20}),
-            ProjectEager.create({title: 'detention1', overdueDays: 0}),
-            ProjectEager.create({title: 'detention2', overdueDays: 0}),
-            ProjectEager.create({title: 'exam1', overdueDays: 0}),
-            ProjectEager.create({title: 'exam2', overdueDays: 0})
-          ])
-          .then(([bart, lisa, detention1, detention2, exam1, exam2]) =>
+          .props({
+            bart: UserEager.create({username: 'bart', age: 20}),
+            lisa: UserEager.create({username: 'lisa', age: 20}),
+            detention1: ProjectEager.create({title: 'detention1', overdueDays: 0}),
+            detention2: ProjectEager.create({title: 'detention2', overdueDays: 0}),
+            exam1: ProjectEager.create({title: 'exam1', overdueDays: 0}),
+            exam2: ProjectEager.create({title: 'exam2', overdueDays: 0})
+          })
+          .then(({ bart, lisa, detention1, detention2, exam1, exam2 }) =>
             Promise
               .all([
                 bart.$set('projects', [detention1, detention2]),
                 lisa.$set('projects', [exam1, exam2])
               ])
-              .then(() => UserEager.findAll<UserEager>({
+              .then(() => UserEager.findAll({
                 where: {age: 20},
                 order: [['username', 'ASC']],
                 include: [ProjectEager]
@@ -1717,7 +1718,7 @@ describe('instance', () => {
             ProjectEager.create({title: 'party', overdueDays: 2})
           ])
           .then(([user, homework, party]) => user.$set('projects', [homework, party]))
-          .then(() => ProjectEager.findAll<ProjectEager>({
+          .then(() => ProjectEager.findAll({
             include: [{
               model: UserEager,
               as: 'poobah'
@@ -1740,7 +1741,7 @@ describe('instance', () => {
               projects[1].save()
             ]);
           })
-          .then(() => ProjectEager.findAll<ProjectEager>({
+          .then(() => ProjectEager.findAll({
             where: {title: 'partymore', overdueDays: 0},
             include: [UserEager]
           }))
@@ -1795,7 +1796,7 @@ describe('instance', () => {
     it("dont return instance that isn't defined", () =>
 
       NiceProject
-        .create<NiceProject>({user: null})
+        .create({user: null})
         .then((project) =>
           NiceProject.findOne({
             where: {
@@ -1817,7 +1818,7 @@ describe('instance', () => {
       NiceUser
         .create({username: 'cuss'})
         .then((user) =>
-          NiceUser.findOne<NiceUser>({
+          NiceUser.findOne({
             where: {
               id: user.id
             },
@@ -1874,14 +1875,14 @@ describe('instance', () => {
 
       Promise
         .all([
-          NiceUser.create<NiceUser>({username: 'fnord', age: 1, isAdmin: true}),
+          NiceUser.create({username: 'fnord', age: 1, isAdmin: true}),
           NiceProject.create({title: 'fnord'})
         ])
         .then(([user, project]) => user.$set('projects', [project]))
         .then(() =>
           Promise.all([
-            NiceUser.findAll<NiceUser>({include: [NiceProject]}),
-            NiceProject.findAll<NiceProject>({include: [NiceUser]})
+            NiceUser.findAll({include: [NiceProject]}),
+            NiceProject.findAll({include: [NiceUser]})
           ])
         )
         .then(([users, projects]) => {
@@ -1935,10 +1936,10 @@ describe('instance', () => {
 
       ParanoidUser.create({username: 'cuss'})
         .then(() =>
-          ParanoidUser.findAll<ParanoidUser>({
-            where: sequelize.and({
-              username: 'cuss'
-            })
+          ParanoidUser.findAll({
+            where: {
+              [sequelize['Op'] ? sequelize['Op'].and : '$and']: { username: 'cuss' }
+            }
           })
         )
         .then((users) => {
@@ -1947,9 +1948,9 @@ describe('instance', () => {
         })
         .then(() =>
           ParanoidUser.findAll({
-            where: sequelize.and({
-              username: 'cuss'
-            })
+            where: {
+              [sequelize['Op'] ? sequelize['Op'].and : '$and']: { username: 'cuss' }
+            }
           })
         )
         .then((users) => {
@@ -1962,9 +1963,9 @@ describe('instance', () => {
       ParanoidUser.create({username: 'cuss'})
         .then(() =>
           ParanoidUser.findAll({
-            where: sequelize.or({
-              username: 'cuss'
-            })
+            where: {
+              [sequelize['Op'] ? sequelize['Op'].or : '$or']: { username: 'cuss' }
+            }
           })
         )
         .then((users) => {
@@ -1973,9 +1974,9 @@ describe('instance', () => {
         })
         .then(() =>
           ParanoidUser.findAll({
-            where: sequelize.or({
-              username: 'cuss'
-            })
+            where: {
+              [sequelize['Op'] ? sequelize['Op'].or : '$or']: { username: 'cuss' }
+            }
           })
         )
         .then((users) => {
@@ -1987,7 +1988,7 @@ describe('instance', () => {
 
       User
         .create({username: "user'name"})
-        .then(() => User.findAll<User>({where: {username: "user'name"}}))
+        .then(() => User.findAll({where: {username: "user'name"}}))
         .then((users) => {
           expect(users.length).to.equal(1);
           expect(users[0].username).to.equal("user'name");
@@ -1998,7 +1999,7 @@ describe('instance', () => {
 
       User
         .create({username: "user''name"})
-        .then(() => User.findAll<User>({where: {username: "user''name"}}))
+        .then(() => User.findAll({where: {username: "user''name"}}))
         .then((users) => {
           expect(users.length).to.equal(1);
           expect(users[0].username).to.equal("user''name");
@@ -2017,7 +2018,7 @@ describe('instance', () => {
     it('does not return the timestamps if the username attribute has been specified', () =>
 
       User.create({username: 'fnord'})
-        .then(() => User.findAll<User>({attributes: ['username']}))
+        .then(() => User.findAll({attributes: ['username']}))
         .then((users) => {
           expect(users[0].createdAt).not.to.exist;
           expect(users[0].username).to.exist;
@@ -2050,7 +2051,7 @@ describe('instance', () => {
 
       return UserDestroy.sync().then(() => {
         return UserDestroy.create({newId: '123ABC', email: 'hello'}).then(() => {
-          return UserDestroy.findOne<UserDestroy>({where: {email: 'hello'}}).then((user) => {
+          return UserDestroy.findOne({where: {email: 'hello'}}).then((user) => {
             return user.destroy();
           });
         });
@@ -2100,9 +2101,9 @@ describe('instance', () => {
 
       User.create({username: 'fnord'}).then(() => {
         const query = {where: {username: 'fnord'}};
-        return User.findAll<User>(query).then((users) => {
+        return User.findAll(query).then((users) => {
           expect(users[0].username).to.equal('fnord');
-          return User.findAll<User>(query).then((_users) => {
+          return User.findAll(query).then((_users) => {
             expect(_users[0].username).to.equal('fnord');
           });
         });
@@ -2116,9 +2117,9 @@ describe('instance', () => {
 
       User.create({username: 'fnord'}).then(() => {
         const query = {where: {username: 'fnord'}};
-        return User.findOne<User>(query).then((user) => {
+        return User.findOne(query).then((user) => {
           expect(user.username).to.equal('fnord');
-          return User.findOne<User>(query).then((_user) => {
+          return User.findOne(query).then((_user) => {
             expect(_user.username).to.equal('fnord');
           });
         });
@@ -2150,7 +2151,7 @@ describe('instance', () => {
 
       return Setting.sync({force: true}).then(() => {
         return Setting.create({settingKey: 'test', boolValue: null, boolValue2: undefined}).then(() => {
-          return Setting.findOne<Setting>({where: {settingKey: 'test'}}).then((setting) => {
+          return Setting.findOne({where: {settingKey: 'test'}}).then((setting) => {
             expect(setting.boolValue).to.equal(null);
             expect(setting.boolValue2).to.equal(null);
             expect(setting.boolValue3).to.equal(null);
@@ -2165,7 +2166,7 @@ describe('instance', () => {
     it('can compare records with Date field', () =>
 
       User.create({username: 'fnord'}).then((user1) =>
-        User.findOne<User>({where: {username: 'fnord'}}).then((user2) => {
+        User.findOne({where: {username: 'fnord'}}).then((user2) => {
           expect(user1.equals(user2)).to.be.true;
         })
       )
@@ -2212,11 +2213,11 @@ describe('instance', () => {
         .then(([user1, project1]) => user1.$set('projects', [project1])
           .then(() =>
             Promise.all([
-              UserAssociationEqual.findOne<UserAssociationEqual>({
+              UserAssociationEqual.findOne({
                 where: {username: 'jimhalpert'},
                 include: [ProjectAssociationEqual]
               }),
-              UserAssociationEqual.create<UserAssociationEqual>({username: 'pambeesly'})
+              UserAssociationEqual.create({username: 'pambeesly'})
             ])
           )
           .then(([user2, user3]) => {
@@ -2395,7 +2396,7 @@ describe('instance', () => {
                   expect(sql.indexOf('bl')).to.be.above(-1);
                 }
               }).then(() => {
-                return MultiPrimary.findAll<MultiPrimary>().then((ms3) => {
+                return MultiPrimary.findAll().then((ms3) => {
                   expect(ms3.length).to.equal(1);
                   expect(ms3[0].bilibili).to.equal('bl');
                   expect(ms3[0].guruguru).to.equal('gu');
@@ -2445,13 +2446,13 @@ describe('instance', () => {
       return ParanoidUser2.sync({force: true}).then(() => {
         return ParanoidUser2.bulkCreate(data);
       }).then(() => {
-        return ParanoidUser2.findOne<ParanoidUser2>({where: {secretValue: '42'}});
+        return ParanoidUser2.findOne({where: {secretValue: '42'}});
       }).then((user) => {
         return user.destroy().then(() => {
           return user.restore();
         });
       }).then(() => {
-        return ParanoidUser2.findOne<ParanoidUser2>({where: {secretValue: '42'}});
+        return ParanoidUser2.findOne({where: {secretValue: '42'}});
       }).then((user) => {
         expect(user).to.be.ok;
         expect(user.username).to.equal('Peter');

--- a/test/specs/model-methods.spec.ts
+++ b/test/specs/model-methods.spec.ts
@@ -23,7 +23,7 @@ describe('model-methods', () => {
 
     static findDemoUser(): Promise<User> {
 
-      return this.findOne<User>({where: {firstName: 'Peter', lastName: 'Parker'}});
+      return this.findOne({where: {firstName: 'Peter', lastName: 'Parker'}});
     }
   }
 

--- a/test/specs/model.spec.ts
+++ b/test/specs/model.spec.ts
@@ -207,7 +207,7 @@ describe('model', () => {
             {aNumber: 10},
             {aNumber: 12}
           ]).then(() => {
-            return User.findAll<User>({where: {aNumber: {$gte: 10}}}).then((users) => {
+            return User.findAll({where: {aNumber: {$gte: 10}}}).then((users) => {
               expect(moment(user.createdAt).format('YYYY-MM-DD')).to.equal('2012-01-01');
               expect(moment(user.updatedAt).format('YYYY-MM-DD')).to.equal('2012-01-02');
               users.forEach((u) => {
@@ -232,8 +232,8 @@ describe('model', () => {
       sequelize.addModels([User]);
 
       return User.sync({force: true}).then(() => {
-        return User.create<User>().then((user) => {
-          return User.create<User>().then((user2) => {
+        return User.create().then((user) => {
+          return User.create().then((user2) => {
             expect(user.aNumber).to.equal(5);
             expect(user2.aNumber).to.equal(5);
             expect(defaultFunction.callCount).to.equal(2);
@@ -260,7 +260,7 @@ describe('model', () => {
       sequelize.addModels([User]);
 
       return User.sync({force: true}).then(() => {
-        return User.create<User>({aNumber: 4}).then((user) => {
+        return User.create({aNumber: 4}).then((user) => {
           expect(user.updatedOn).to.exist;
           expect(user.dateCreated).to.exist;
           return user.destroy().then(() => {
@@ -284,7 +284,7 @@ describe('model', () => {
       sequelize.addModels([User]);
 
       return User.sync({force: true}).then(() => {
-        return User.create<User>({
+        return User.create({
           name: 'heyo'
         }).then((user) => {
           expect(user.createdAt).not.to.exist;
@@ -322,7 +322,7 @@ describe('model', () => {
       sequelize.addModels([Task]);
 
       return Task.sync({force: true}).then(() => {
-        return Task.build<Task>().save().then((record) => {
+        return Task.build().save().then((record) => {
           expect(record.title).to.be.a('string');
           expect(record.title).to.equal('');
           expect(titleSetter.notCalled).to.be.ok; // The setter method should not be invoked for default values
@@ -578,11 +578,11 @@ describe('model', () => {
       }
       sequelize.addModels([Task]);
 
-      expect(Task.build<Task>().title).to.equal('a task!');
-      expect(Task.build<Task>().foo).to.equal(2);
-      expect(Task.build<Task>().bar).to.not.be.ok;
-      expect(Task.build<Task>().foobar).to.equal('asd');
-      expect(Task.build<Task>().flag).to.be.false;
+      expect(Task.build().title).to.equal('a task!');
+      expect(Task.build().foo).to.equal(2);
+      expect(Task.build().bar).to.not.be.ok;
+      expect(Task.build().foobar).to.equal('asd');
+      expect(Task.build().flag).to.be.false;
     });
 
     it('fills the objects with default values', () => {
@@ -610,11 +610,11 @@ describe('model', () => {
       }
       sequelize.addModels([Task]);
 
-      expect(Task.build<Task>().title).to.equal('a task!');
-      expect(Task.build<Task>().foo).to.equal(2);
-      expect(Task.build<Task>().bar).to.not.be.ok;
-      expect(Task.build<Task>().foobar).to.equal('asd');
-      expect(Task.build<Task>().flag).to.be.false;
+      expect(Task.build().title).to.equal('a task!');
+      expect(Task.build().foo).to.equal(2);
+      expect(Task.build().bar).to.not.be.ok;
+      expect(Task.build().foobar).to.equal('asd');
+      expect(Task.build().flag).to.be.false;
     });
 
     it('attaches getter and setter methods from attribute definition', () => {
@@ -633,9 +633,9 @@ describe('model', () => {
       }
       sequelize.addModels([Product]);
 
-      expect(Product.build<Product>({price: 42}).price).to.equal('answer = 84');
+      expect(Product.build({price: 42}).price).to.equal('answer = 84');
 
-      const p = Product.build<Product>({price: 1});
+      const p = Product.build({price: 1});
       expect(p.price).to.equal('answer = 43');
 
       p.price = 0;
@@ -668,8 +668,8 @@ describe('model', () => {
       }
       sequelize.addModels([Product]);
 
-      expect(Product.build<Product>({price: 20}).priceInCents).to.equal(20 * 100);
-      expect(Product.build<Product>({priceInCents: 30 * 100}).price).to.equal('$' + 30);
+      expect(Product.build({price: 20}).priceInCents).to.equal(20 * 100);
+      expect(Product.build({priceInCents: 30 * 100}).price).to.equal('$' + 30);
     });
 
     it('attaches getter and setter methods from options only if not defined in attribute', () => {
@@ -703,7 +703,7 @@ describe('model', () => {
       }
       sequelize.addModels([Product]);
 
-      const p = Product.build<Product>({price1: 1, price2: 2});
+      const p = Product.build({price1: 1, price2: 2});
 
       expect(p.price1).to.equal(10);
       expect(p.price2).to.equal(20);
@@ -756,7 +756,7 @@ describe('model', () => {
 
         sequelize.addModels([Product, Tag, User]);
 
-        const product = Product.build<Product>({
+        const product = Product.build({
           id: 1,
           title: 'Chair',
           tags: [
@@ -822,7 +822,7 @@ describe('model', () => {
 
         sequelize.addModels([Product, Tag, User]);
 
-        const product = Product.build<Product>({
+        const product = Product.build({
           id: 1,
           title: 'Chair',
           categories: [
@@ -894,7 +894,7 @@ describe('model', () => {
           return User.create({username: 'A fancy name'});
         })
         .then(() => {
-          return User.findOne<User>({where: []});
+          return User.findOne({where: <any>[]});
         })
         .then((u) => {
           expect(u.username).to.equal('A fancy name');
@@ -918,13 +918,13 @@ describe('model', () => {
           return User.create({username: 'a2'});
         })
         .then(() => {
-          return User.findOne<User>({where: {username: 'a2'}, include: []});
+          return User.findOne({where: {username: 'a2'}, include: []});
         })
         .then((u) => {
           expect(u.username).to.equal('a2');
         })
         .then(() => {
-          return User.findOne<User>({where: {username: 'a1'}, include: []});
+          return User.findOne({where: {username: 'a1'}, include: []});
         })
         .then((u) => {
           expect(u.username).to.equal('a1');
@@ -971,8 +971,8 @@ describe('model', () => {
     describe('returns an instance if it already exists', () => {
       it('with a single find field', () => {
 
-        return MainUser.create<MainUser>({username: 'Username'}).then((user) => {
-          return MainUser.findOrInitialize<MainUser>({
+        return MainUser.create({username: 'Username'}).then((user) => {
+          return MainUser.findOrInitialize({
             where: {username: user.username}
           }).then(([_user, initialized]) => {
             expect(_user.id).to.equal(user.id);
@@ -984,8 +984,8 @@ describe('model', () => {
 
       it('with multiple find fields', () => {
 
-        return MainUser.create<MainUser>({username: 'Username', data: 'data'}).then((user) => {
-          return MainUser.findOrInitialize<MainUser>({
+        return MainUser.create({username: 'Username', data: 'data'}).then((user) => {
+          return MainUser.findOrInitialize({
             where: {
               username: user.username,
               data: user.data
@@ -1007,7 +1007,7 @@ describe('model', () => {
           data: 'ThisIsData'
         };
 
-        return MainUser.findOrInitialize<MainUser>({
+        return MainUser.findOrInitialize({
           where: data,
           defaults: defaultValues
         }).then(([user, initialized]) => {

--- a/test/specs/models/sequelize.spec.ts
+++ b/test/specs/models/sequelize.spec.ts
@@ -149,7 +149,7 @@ describe('sequelize', () => {
 
         expect(() => Gamer.build({})).not.to.throw;
 
-        const gamer = Gamer.build<Gamer>({nickname: 'the_gamer'});
+        const gamer = Gamer.build({nickname: 'the_gamer'});
 
         expect(gamer.nickname).to.equal('the_gamer');
       });
@@ -164,7 +164,7 @@ describe('sequelize', () => {
 
         expect(() => Game.build({})).not.to.throw;
 
-        const game = Game.build<Game>({title: 'Commander Keen'});
+        const game = Game.build({title: 'Commander Keen'});
 
         expect(game.title).to.equal('Commander Keen');
       });

--- a/test/specs/scopes.spec.ts
+++ b/test/specs/scopes.spec.ts
@@ -35,7 +35,7 @@ describe('scopes', () => {
     const OWNER = 'bob';
 
     beforeEach(() => ShoeWithScopes
-      .create<ShoeWithScopes>({
+      .create({
         secretKey: 'j435njk3',
         primaryColor: 'red',
         secondaryColor: 'blue',
@@ -93,7 +93,7 @@ describe('scopes', () => {
       it('should consider scopes and additional included model (object)', () =>
         expect(ShoeWithScopes
           .scope('full')
-          .findOne<ShoeWithScopes>({
+          .findOne({
             include: [{
               model: Person,
             }]


### PR DESCRIPTION
Adds type inference to most static methods on `Model` and its subclasses (`create()`, `findAll()`, etc) that previously required user-supplied generic parameters to correctly yield the correct return type.

`Person.findAll<Person>` simply becomes `Person.findAll()`, and TypeScript will automatically infer the correct return type.  The old type signature will also continue to work.  See https://github.com/Microsoft/TypeScript/issues/5863 for an explanation of what's going on under the hood that allows this to work.

New overloads have been added to `Model.create<T extends Model<T>, A>(vals: A) : T` and its cousins, so that `Model.create<A>(vals: A) : T` may also be used in as a shorthand for when developers want to provide strict typings for `A`, but don't need to override the automatic inference of `T`.

Updates tests to run against the current version of Sequelize v4, and uses newer Bluebird type definitions (a milder version of #166 until we can figure out what to do there -- necessary because the older version had an inaccurate definition of `Promise.all`).