### PR TITLE
fix build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,14 @@ export class ShoeWithScopes extends Model<ShoeWithScopes> {
 }
 ```
 
+Note that `Model.scope()` and `Model.unscoped()` are **not** typesafe.  Their return values must be explicily cast back to the correct Model type:
+
+```typescript
+(ShoeWithScopes.scope('full') as typeof ShoeWithScopes)
+.findAll(args)
+.then(shoes => '...');
+```
+
 ## Hooks
 Hooks can be attached to your models. All Model-level hooks are supported. See [the related unit tests](test/models/Hook.ts) for a summary.
 

--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -130,7 +130,7 @@ export declare abstract class Model<T> extends Hooks {
    * @return Model A reference to the model, with the scope(s) applied. Calling scope again on the returned
    *     model will clear the previous scope.
    */
-  static scope<T extends Model<T>>(this: (new () => T), options?: string | string[] | ScopeOptions | WhereOptions<any>): typeof T;
+  static scope(options?: string | string[] | ScopeOptions | WhereOptions<any>): typeof Model;
 
   /**
    * Search for multiple instances.
@@ -291,21 +291,18 @@ export declare abstract class Model<T> extends Hooks {
    */
   static build<T extends Model<T>>(this: (new () => T), record?: any, options?: IBuildOptions): T;
   static build<T extends Model<T>, A>(this: (new () => T), record?: A, options?: IBuildOptions): T;
-  static build<A>(this: (new () => T), record?: A, options?: IBuildOptions): T;
 
   /**
    * Undocumented bulkBuild
    */
   static bulkBuild<T extends Model<T>>(this: (new () => T), records: any[], options?: IBuildOptions): T[];
   static bulkBuild<T extends Model<T>, A>(this: (new () => T), records: A[], options?: IBuildOptions): T[];
-  static bulkBuild<A>(this: (new () => T), records: A[], options?: IBuildOptions): T[];
 
   /**
    * Builds a new model instance and calls save on it.
    */
   static create<T extends Model<T>>(this: (new () => T), values?: any, options?: ICreateOptions): Promise<T>;
   static create<T extends Model<T>, A>(this: (new () => T), values?: A, options?: ICreateOptions): Promise<T>;
-  static create<A>(this: (new () => T), values?: A, options?: ICreateOptions): Promise<T>;
 
   /**
    * Find a row that matches the query, or build (but don't save) the row if none is found.
@@ -313,11 +310,9 @@ export declare abstract class Model<T> extends Hooks {
    */
   static findOrInitialize<T extends Model<T>>(this: (new () => T), options: IFindOrInitializeOptions<any>): Promise<[T, boolean]>;
   static findOrInitialize<T extends Model<T>, A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
-  static findOrInitialize<A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
 
   static findOrBuild<T extends Model<T>>(this: (new () => T), options: IFindOrInitializeOptions<any>): Promise<[T, boolean]>;
   static findOrBuild<T extends Model<T>, A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
-  static findOrBuild<A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
 
   /**
    * Find a row that matches the query, or build and save the row if none is found
@@ -332,7 +327,6 @@ export declare abstract class Model<T> extends Hooks {
    */
   static findOrCreate<T extends Model<T>>(this: (new () => T), options: IFindOrInitializeOptions<any>): Promise<[T, boolean]>;
   static findOrCreate<T extends Model<T>, A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
-  static findOrCreate<A>(this: (new () => T), options: IFindOrInitializeOptions<A>): Promise<[T, boolean]>;
 
   /**
    * A more performant findOrCreate that will not work under a transaction (at least not in postgres)
@@ -340,7 +334,6 @@ export declare abstract class Model<T> extends Hooks {
    */
   static findCreateFind<T extends Model<T>>(this: (new () => T), options: IFindCreateFindOptions<any>): Promise<[T, boolean]>;
   static findCreateFind<T extends Model<T>, A>(this: (new () => T), options: IFindCreateFindOptions<A>): Promise<[T, boolean]>;
-  static findCreateFind<A>(this: (new () => T), options: IFindCreateFindOptions<A>): Promise<[T, boolean]>;
 
   /**
    * Insert or update a single row. An update will be executed if a row which matches the supplied values on
@@ -378,7 +371,6 @@ export declare abstract class Model<T> extends Hooks {
    */
   static bulkCreate<T extends Model<T>>(this: (new () => T), records: any[], options?: BulkCreateOptions): Promise<T[]>;
   static bulkCreate<T extends Model<T>, A>(this: (new () => T), records: A[], options?: BulkCreateOptions): Promise<T[]>;
-  static bulkCreate<A>(this: (new () => T), records: A[], options?: BulkCreateOptions): Promise<T[]>;
 
   /**
    * Truncate all instances of the model. This is a convenient method for Model.destroy({ truncate: true }).
@@ -404,8 +396,6 @@ export declare abstract class Model<T> extends Hooks {
    */
   static update<T extends Model<T>>(this: (new () => T), values: any, options: UpdateOptions): Promise<[number, Array<T>]>;
   static update<T extends Model<T>, A>(this: (new () => T), values: A, options: UpdateOptions): Promise<[number, Array<T>]>;
-  static update<A>(this: (new () => T), values: A, options: UpdateOptions): Promise<[number, Array<T>]>;
-
   /**
    * Run a describe query on the table. The result will be return to the listener as a hash of attributes and
    * their types.
@@ -415,7 +405,7 @@ export declare abstract class Model<T> extends Hooks {
   /**
    * Unscope the model
    */
-  static unscoped<T extends Model<T>>(this: (new () => T)): typeof T;
+  static unscoped(): typeof Model;
 
   /**
    * A reference to the sequelize instance

--- a/package-lock.json
+++ b/package-lock.json
@@ -4590,9 +4590,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
       "dev": true
     },
     "underscore.string": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "sqlite3": "3.1.8",
     "ts-node": "3.0.4",
     "tslint": "4.3.1",
-    "typescript": "2.5.3",
+    "typescript": "2.6.1",
     "uuid-validate": "0.0.2"
   },
   "engines": {

--- a/test/specs/instance.spec.ts
+++ b/test/specs/instance.spec.ts
@@ -816,7 +816,7 @@ describe('instance', () => {
 
     it('should update the associations after one element deleted', () =>
       Team
-        .create<{name: string; players: Array<{name: string}>}>({
+        .create({
           name: 'the team',
           players: [{
             name: 'the player1'

--- a/test/specs/scopes.spec.ts
+++ b/test/specs/scopes.spec.ts
@@ -60,18 +60,18 @@ describe('scopes', () => {
 
     it('should consider other scopes', () =>
 
-      ShoeWithScopes.scope('full').findOne()
+      (ShoeWithScopes.scope('full') as typeof ShoeWithScopes).findOne()
         .then(shoe => {
 
           expect(shoe).to.have.property('manufacturer').which.is.not.null;
           expect(shoe).to.have.property('manufacturer').which.have.property('brand', BRAND);
         })
-        .then(() => ShoeWithScopes.scope('yellow').findAll())
+        .then(() => (ShoeWithScopes.scope('yellow') as typeof ShoeWithScopes).findAll())
         .then(yellowShoes => {
 
           expect(yellowShoes).to.be.empty;
         })
-        .then(() => ShoeWithScopes.scope('noImg').findAll())
+        .then(() => (ShoeWithScopes.scope('noImg')  as typeof ShoeWithScopes).findAll())
         .then(noImgShoes => {
 
           expect(noImgShoes).to.be.not.empty;
@@ -79,9 +79,8 @@ describe('scopes', () => {
     );
 
     it('should not consider default scope due to unscoped call', () =>
-
-      ShoeWithScopes
-        .unscoped()
+      (ShoeWithScopes
+        .unscoped() as typeof ShoeWithScopes)
         .findOne()
         .then(shoe => {
           expect(shoe).to.have.property('secretKey').which.is.a('string');
@@ -91,8 +90,8 @@ describe('scopes', () => {
     describe('with include options', () => {
 
       it('should consider scopes and additional included model (object)', () =>
-        expect(ShoeWithScopes
-          .scope('full')
+        expect(
+          (ShoeWithScopes.scope('full') as typeof ShoeWithScopes)
           .findOne({
             include: [{
               model: Person,
@@ -107,8 +106,8 @@ describe('scopes', () => {
       );
 
       it('should consider scopes and additional included model (model)', () =>
-        expect(ShoeWithScopes
-          .scope('full')
+        expect(
+          (ShoeWithScopes.scope('full') as typeof ShoeWithScopes)
           .findOne({
             include: [Person]
           })
@@ -122,8 +121,7 @@ describe('scopes', () => {
 
       it('should not consider default scope due to unscoped call, but additonal includes (object)', () =>
 
-        ShoeWithScopes
-          .unscoped()
+        (ShoeWithScopes.unscoped() as typeof ShoeWithScopes)
           .findOne({
             include: [{model: Person}]
           })
@@ -135,8 +133,8 @@ describe('scopes', () => {
 
       it('should not consider default scope due to unscoped call, but additonal includes (model)', () =>
 
-        ShoeWithScopes
-          .unscoped()
+        (ShoeWithScopes
+        .unscoped() as typeof ShoeWithScopes)
           .findOne({
             include: [Person]
           })
@@ -161,10 +159,9 @@ describe('scopes', () => {
         );
 
         it('should consider scope of included model (with own scope)', () =>
-          ShoeWithScopes
-            .scope('red')
+          (ShoeWithScopes.scope('red') as typeof ShoeWithScopes)
             .findOne({
-              include: [Manufacturer.scope('brandOnly')]
+              include: [Manufacturer.scope('brandOnly') as typeof Manufacturer]
             })
             .then(shoe => {
               expect(shoe).to.have.property('manufacturer')
@@ -180,8 +177,7 @@ describe('scopes', () => {
     describe('with nested scope', () => {
 
       it('should consider nested scope', () =>
-        ShoeWithScopes
-          .scope('manufacturerWithScope')
+        (ShoeWithScopes.scope('manufacturerWithScope') as typeof ShoeWithScopes)
           .findOne()
           .then(shoe => {
             expect(shoe).to.have.property('manufacturer')
@@ -191,8 +187,7 @@ describe('scopes', () => {
       );
 
       it('should not consider nested scope', () =>
-        ShoeWithScopes
-          .scope('full')
+        (ShoeWithScopes.scope('full') as typeof ShoeWithScopes)
           .findOne()
           .then(shoe => {
             expect(shoe).to.have.property('manufacturer')
@@ -206,8 +201,7 @@ describe('scopes', () => {
     describe('with scope function', () => {
 
       it('should find appropriate shoe due to correctly passed scope function param', () =>
-        ShoeWithScopes
-          .scope({method: ['primaryColor', 'red']})
+        (ShoeWithScopes.scope({method: ['primaryColor', 'red']})  as typeof ShoeWithScopes)
           .findOne()
           .then(shoe => {
             expect(shoe).to.have.property('primaryColor', 'red');
@@ -215,8 +209,7 @@ describe('scopes', () => {
       );
 
       it('should find appropriate shoe due to correctly passed scope function param including associated model', () =>
-        ShoeWithScopes
-          .scope({method: ['primaryColorWithManufacturer', 'red']})
+        (ShoeWithScopes.scope({method: ['primaryColorWithManufacturer', 'red']})  as typeof ShoeWithScopes)
           .findOne()
           .then(shoe => {
             expect(shoe).to.have.property('primaryColor', 'red');

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -6,10 +6,9 @@
     "emitDecoratorMetadata": true,
     "sourceMap": true,
     "strictNullChecks": false,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "pretty": true,
-    "skipLibCheck": true,
-    "lib": ["es2015"]
+    "lib": ["es2017"]
   },
   "include": [
     "./**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,7 @@
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "pretty": true,
-    "skipLibCheck": true,
-    "lib": ["es2015"]
+    "lib": ["es2017"]
   },
   "include": [
     "lib/**/*"


### PR DESCRIPTION
Fixes #190

Adds a documentation note about the fact that scopes effectively break typesafety unless an explicit cast is provided.  