### PR TITLE
Add npm5 git support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "exec-tests": "mocha",
     "test": "npm run test-v4 && npm run test-v3",
     "cover": "npm run cover-v4 && npm run cover-v3",
-    "lint": "tslint ."
+    "lint": "tslint .",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Wanted to use my update but you haven't released it yet so would be nice to just install it directly from your git without the need to publish (something I miss from bower) :)

You can install the latest like:
```
npm i github:intellix/sequelize-typescript#npm5-git-support
```