### PR TITLE
Allow passing the scopes as consecutive arguments

### DIFF
--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -135,6 +135,7 @@ export declare abstract class Model<T> extends Hooks {
    *     model will clear the previous scope.
    */
   static scope<T>(this: NonAbstractTypeOfModel<T>, options?: string | string[] | ScopeOptions | WhereOptions<any>): NonAbstractTypeOfModel<T>;
+  static scope<T>(this: NonAbstractTypeOfModel<T>, ...scopes: string[]): NonAbstractTypeOfModel<T>;
 
   /**
    * Search for multiple instances.


### PR DESCRIPTION
This is documented [here](http://docs.sequelizejs.com/manual/tutorial/scopes.html#merging).

> Several scopes can be applied simultaneously by passing an array of scopes to .scope, or by passing the scopes as consecutive arguments.

```JavaScript
// These two are equivalent
Project.scope('deleted', 'activeUsers').findAll();
Project.scope(['deleted', 'activeUsers']).findAll();
```