### PR TITLE
Added generic types for scope decorators

### DIFF
--- a/lib/annotations/DefaultScope.ts
+++ b/lib/annotations/DefaultScope.ts
@@ -1,11 +1,12 @@
 import 'reflect-metadata';
 import {addScopeOptions} from "../services/scopes";
 import {IScopeFindOptions} from "../interfaces/IScopeFindOptions";
+import {Model} from "../models/Model";
 
 /**
  * Sets default scope for annotated class
  */
-export function DefaultScope(scope: IScopeFindOptions | Function): Function {
+export function DefaultScope<T extends Model<T> = any>(scope: IScopeFindOptions<T> | Function): Function {
 
   return (target: any) => {
 

--- a/lib/annotations/Scopes.ts
+++ b/lib/annotations/Scopes.ts
@@ -1,11 +1,12 @@
 import 'reflect-metadata';
 import {addScopeOptions} from "../services/scopes";
 import {IDefineScopeOptions} from "../interfaces/IDefineScopeOptions";
+import {Model} from "../models/Model";
 
 /**
  * Sets scopes for annotated class
  */
-export function Scopes(scopes: IDefineScopeOptions): Function {
+export function Scopes<T extends Model<T> = any>(scopes: IDefineScopeOptions<T>): Function {
 
   return (target: any) => {
 

--- a/lib/interfaces/IBaseIncludeOptions.ts
+++ b/lib/interfaces/IBaseIncludeOptions.ts
@@ -1,9 +1,10 @@
 import {WhereOptions, IncludeThroughOptions, FindOptionsAttributesArray} from 'sequelize';
+import {Model} from "../models/Model";
 
 /**
  * Complex include options
  */
-export interface IBaseIncludeOptions {
+export interface IBaseIncludeOptions<T = Model<any>> {
 
   /**
    * The alias of the relation, in case the model you want to eagerly load is aliassed. For `hasOne` /
@@ -20,7 +21,7 @@ export interface IBaseIncludeOptions {
   /**
    * A list of attributes to select from the child model
    */
-  attributes?: FindOptionsAttributesArray | { include?: FindOptionsAttributesArray, exclude?: string[] };
+  attributes?: FindOptionsAttributesArray<T> | { include?: FindOptionsAttributesArray<T>, exclude?: keyof T };
 
   /**
    * If true, converts to an inner join, which means that the parent model will only be loaded if it has any

--- a/lib/interfaces/IBuildOptions.ts
+++ b/lib/interfaces/IBuildOptions.ts
@@ -2,7 +2,7 @@ import {ReturningOptions} from 'sequelize';
 import {IIncludeOptions} from "./IIncludeOptions";
 import {Model} from "../models/Model";
 
-export interface IBuildOptions extends ReturningOptions {
+export interface IBuildOptions<T extends Model<any> = Model<any>> extends ReturningOptions {
 
   /**
    * If set to true, values will ignore field and virtual setters.
@@ -17,5 +17,5 @@ export interface IBuildOptions extends ReturningOptions {
   /**
    * an array of include options - Used to build prefetched/included model instances. See `set`
    */
-  include?: Array<typeof Model | IIncludeOptions>;
+  include?: Array<typeof Model | IIncludeOptions<T>>;
 }

--- a/lib/interfaces/ICountOptions.ts
+++ b/lib/interfaces/ICountOptions.ts
@@ -12,7 +12,7 @@ export interface ICountOptions<T> extends LoggingOptions, SearchPathOptions {
   /**
    * Include options. See `find` for details
    */
-  include?: Array<typeof Model | IIncludeOptions>;
+  include?: Array<typeof Model | IIncludeOptions<T>>;
 
   /**
    * Apply COUNT(DISTINCT(col))
@@ -22,7 +22,7 @@ export interface ICountOptions<T> extends LoggingOptions, SearchPathOptions {
   /**
    * Used in conjustion with `group`
    */
-  attributes?: Array<string | [string, string]>;
+  attributes?: Array<keyof T | [keyof T, string]>;
 
   /**
    * For creating complex counts. Will return multiple rows as needed.

--- a/lib/interfaces/ICreateOptions.ts
+++ b/lib/interfaces/ICreateOptions.ts
@@ -1,10 +1,11 @@
 import {InstanceSaveOptions} from 'sequelize';
 import {IBuildOptions} from "./IBuildOptions";
+import {Model} from "../models/Model";
 
 /**
  * Options for Model.create method
  */
-export interface ICreateOptions extends IBuildOptions, InstanceSaveOptions {
+export interface ICreateOptions<T extends Model<T> = Model<any>> extends IBuildOptions<T>, InstanceSaveOptions {
 
   /**
    * On Duplicate

--- a/lib/interfaces/IDefineScopeOptions.ts
+++ b/lib/interfaces/IDefineScopeOptions.ts
@@ -1,6 +1,6 @@
 import {IScopeFindOptions} from "./IScopeFindOptions";
 
-export interface IDefineScopeOptions {
+export interface IDefineScopeOptions<T = any> {
 
-  [scopeName: string]: IScopeFindOptions | Function | undefined;
+  [scopeName: string]: IScopeFindOptions<T> | Function | undefined;
 }

--- a/lib/interfaces/IFindOptions.ts
+++ b/lib/interfaces/IFindOptions.ts
@@ -21,7 +21,7 @@ export interface IFindOptions<T> extends LoggingOptions, SearchPathOptions {
    * `Sequelize.literal`, `Sequelize.fn` and so on), and the second is the name you want the attribute to
    * have in the returned instance
    */
-  attributes?: FindOptionsAttributesArray | { include?: FindOptionsAttributesArray, exclude?: Array<string> };
+  attributes?: FindOptionsAttributesArray<T> | { include?: FindOptionsAttributesArray<T>, exclude?: Array<keyof T> };
 
   /**
    * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will
@@ -35,7 +35,7 @@ export interface IFindOptions<T> extends LoggingOptions, SearchPathOptions {
    * If your association are set up with an `as` (eg. `X.hasMany(Y, { as: 'Z }`, you need to specify Z in
    * the as attribute when eager loading Y).
    */
-  include?: Array<typeof Model | IIncludeOptions>;
+  include?: Array<typeof Model | IIncludeOptions<T>>;
 
   /**
    * Specifies an ordering. If a string is provided, it will be escaped. Using an array, you can provide

--- a/lib/interfaces/IIncludeOptions.ts
+++ b/lib/interfaces/IIncludeOptions.ts
@@ -5,7 +5,7 @@ import {IBaseIncludeOptions} from "./IBaseIncludeOptions";
 /**
  * Complex include options
  */
-export interface IIncludeOptions extends IBaseIncludeOptions {
+export interface IIncludeOptions<T = any> extends IBaseIncludeOptions<T> {
 
   /**
    * The model you want to eagerly load
@@ -20,7 +20,7 @@ export interface IIncludeOptions extends IBaseIncludeOptions {
   /**
    * Load further nested related models
    */
-  include?: Array<typeof Model | IIncludeOptions>;
+  include?: Array<typeof Model | IIncludeOptions<T>>;
 
   /**
    * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will

--- a/lib/interfaces/IScopeFindOptions.ts
+++ b/lib/interfaces/IScopeFindOptions.ts
@@ -6,12 +6,12 @@ import {ModelClassGetter} from "../types/ModelClassGetter";
 /* tslint:disable:array-type */
 /* tslint:disable:max-line-length */
 
-export interface IScopeFindOptions extends LoggingOptions, SearchPathOptions {
+export interface IScopeFindOptions<T = any> extends LoggingOptions, SearchPathOptions {
 
   /**
    * A hash of attributes to describe your search. See above for examples.
    */
-  where?: WhereOptions<any> | Array<col | and | or | string> | col | and | or | string;
+  where?: WhereOptions<T> | Array<col | and | or | string> | col | and | or | string;
 
   /**
    * A list of the attributes that you want to select. To rename an attribute, you can pass an array, with
@@ -19,7 +19,7 @@ export interface IScopeFindOptions extends LoggingOptions, SearchPathOptions {
    * `Sequelize.literal`, `Sequelize.fn` and so on), and the second is the name you want the attribute to
    * have in the returned instance
    */
-  attributes?: FindOptionsAttributesArray | { include?: FindOptionsAttributesArray, exclude?: Array<string> };
+  attributes?: FindOptionsAttributesArray<T> | { include?: FindOptionsAttributesArray<T>, exclude?: Array<keyof T> };
 
   /**
    * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will
@@ -33,7 +33,7 @@ export interface IScopeFindOptions extends LoggingOptions, SearchPathOptions {
    * If your association are set up with an `as` (eg. `X.hasMany(Y, { as: 'Z }`, you need to specify Z in
    * the as attribute when eager loading Y).
    */
-  include?: Array<ModelClassGetter | IScopeIncludeOptions>;
+  include?: Array<ModelClassGetter | IScopeIncludeOptions<T>>;
 
   /**
    * Specifies an ordering. If a string is provided, it will be escaped. Using an array, you can provide

--- a/lib/interfaces/IScopeIncludeOptions.ts
+++ b/lib/interfaces/IScopeIncludeOptions.ts
@@ -5,7 +5,7 @@ import {IBaseIncludeOptions} from "./IBaseIncludeOptions";
 /**
  * Complex include options
  */
-export interface IScopeIncludeOptions extends IBaseIncludeOptions {
+export interface IScopeIncludeOptions<T = any> extends IBaseIncludeOptions<T> {
 
   /**
    * The model you want to eagerly load
@@ -20,6 +20,6 @@ export interface IScopeIncludeOptions extends IBaseIncludeOptions {
   /**
    * Load further nested related models
    */
-  include?: Array<ModelClassGetter | IScopeIncludeOptions>;
+  include?: Array<ModelClassGetter | IScopeIncludeOptions<T>>;
 
 }

--- a/lib/interfaces/IScopeOptions.ts
+++ b/lib/interfaces/IScopeOptions.ts
@@ -1,7 +1,7 @@
 import {IScopeFindOptions} from "./IScopeFindOptions";
 import {IDefineScopeOptions} from "./IDefineScopeOptions";
 
-export interface IScopeOptions extends IDefineScopeOptions {
+export interface IScopeOptions<T = any> extends IDefineScopeOptions<T> {
 
-  defaultScope?: IScopeFindOptions | Function;
+  defaultScope?: IScopeFindOptions<T> | Function;
 }

--- a/lib/models/BaseModel.ts
+++ b/lib/models/BaseModel.ts
@@ -95,7 +95,7 @@ export abstract class BaseModel {
   /**
    * Prepares build options for instantiation of a model
    */
-  static prepareInstantiationOptions(options: BuildOptions, source: any): BuildOptions {
+  static prepareInstantiationOptions<T>(options: BuildOptions<T>, source: any): BuildOptions<T> {
 
     options = inferAlias(options, source);
 

--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -28,7 +28,7 @@ type Diff<T extends string, U extends string> = ({[P in T]: P} & {[P in U]: neve
 type Omit<T, K extends keyof T> = {[P in Diff<keyof T, K>]: T[P]};
 
 type GetAttributes<T extends Model<T>> =
-  Partial<Omit<T,keyof Model<any>>> | {
+  Partial<Omit<T, keyof Model<any>>> | {
   id?: number|any;
   createdAt?: Date|any;
   updatedAt?: Date|any;
@@ -38,7 +38,7 @@ type GetAttributes<T extends Model<T>> =
 
 export declare abstract class Model<T> extends Hooks {
 
-  constructor(values?: any, options?: IBuildOptions);
+  constructor(values?: any, options?: IBuildOptions<Model<T>>);
 
   static isInitialized: boolean;
 
@@ -97,7 +97,7 @@ export declare abstract class Model<T> extends Hooks {
    * @param {Object}          [options]
    * @param {Boolean}         [options.override=false]
    */
-  static addScope<T extends Model<T>>(name: string, scope: IFindOptions<T> | Function, options?: AddScopeOptions): void;
+  static addScope<T = any>(name: string, scope: IFindOptions<T> | Function, options?: AddScopeOptions): void;
 
   /**
    * Apply a scope created in `define` to the model. First let's look at how to create scopes:
@@ -306,20 +306,20 @@ export declare abstract class Model<T> extends Hooks {
   /**
    * Builds a new model instance. Values is an object of key value pairs, must be defined but can be empty.
    */
-  static build<T extends Model<T>>(this: (new () => T), record?: GetAttributes<T>, options?: IBuildOptions): T;
-  static build<T extends Model<T>, A>(this: (new () => T), record?: A, options?: IBuildOptions): T;
+  static build<T extends Model<T>>(this: (new () => T), record?: GetAttributes<T>, options?: IBuildOptions<T>): T;
+  static build<T extends Model<T>, A>(this: (new () => T), record?: A, options?: IBuildOptions<T>): T;
 
   /**
    * Undocumented bulkBuild
    */
-  static bulkBuild<T extends Model<T>>(this: (new () => T), records: GetAttributes<T>[], options?: IBuildOptions): T[];
-  static bulkBuild<T extends Model<T>, A>(this: (new () => T), records: A[], options?: IBuildOptions): T[];
+  static bulkBuild<T extends Model<T>>(this: (new () => T), records: GetAttributes<T>[], options?: IBuildOptions<T>): T[];
+  static bulkBuild<T extends Model<T>, A>(this: (new () => T), records: A[], options?: IBuildOptions<T>): T[];
 
   /**
    * Builds a new model instance and calls save on it.
    */
-  static create<T extends Model<T>>(this: (new () => T), values?: GetAttributes<T>, options?: ICreateOptions): Promise<T>;
-  static create<T extends Model<T>, A>(this: (new () => T), values?: A, options?: ICreateOptions): Promise<T>;
+  static create<T extends Model<T>>(this: (new () => T), values?: GetAttributes<T>, options?: ICreateOptions<T>): Promise<T>;
+  static create<T extends Model<T>, A>(this: (new () => T), values?: A, options?: ICreateOptions<T>): Promise<T>;
 
   /**
    * Find a row that matches the query, or build (but don't save) the row if none is found.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,9 +76,9 @@
       "integrity": "sha1-tkd8qal+UmXyrGf56nBOrl4Or00="
     },
     "@types/sequelize": {
-      "version": "4.0.79",
-      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.0.79.tgz",
-      "integrity": "sha512-rtBBoxXNrSyEaBJm1duQy8C6AeZ4EoSI2MzI/twAVZShKa9y4tAhMiFWwACkrp1VInbJ1aSB+IaCtL+B9btpNA==",
+      "version": "4.27.1",
+      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.27.1.tgz",
+      "integrity": "sha512-np3A7YlxYo3v+lSuHROUzk2CgMdZAMV/xQH1kwDSpeWmAlRP10JacR/ark99myTvu9Q8T0TgKbEFU5to8Qzk6w==",
       "requires": {
         "@types/bluebird": "3.5.18",
         "@types/continuation-local-storage": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/bluebird": "3.5.18",
     "@types/node": "6.0.41",
     "@types/reflect-metadata": "0.0.4",
-    "@types/sequelize": "4.0.79",
+    "@types/sequelize": "4.27.1",
     "es6-shim": "0.35.3",
     "glob": "7.1.2"
   },


### PR DESCRIPTION
This PR allows typing the scope decorators, to allow stricter type checking:

```ts
@DefaultScope<Person>({
  attributes: ['id'],
  where: {id: 'foo'}
})
@Scopes<Person>({
  bar: {
    attributes: ['id']
  }
})
@Table
export class Person extends Model<Person> {

  @PrimaryKey
  id: string;
}
```

The tests are all passing, but it's dependent on another PR for [@types/sequelize](/DefinitelyTyped/DefinitelyTyped/tree/master/types/sequelize), [PR 22755](/DefinitelyTyped/DefinitelyTyped/pull/22755), which is currently opened.

I haven't added any additional tests yet, and I'd very much appreciate the help!