### PR TITLE
Revert "Change generic return type of $get from <R, R[]> to <R>"

### DIFF
--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -444,7 +444,7 @@ export declare abstract class Model<T extends Model<T>> extends Hooks {
   /**
    * Returns related instance (specified by propertyKey) of source instance
    */
-  $get<R extends Model<R>>(propertyKey: string, options?: any): Promise<R>; // TODO@robin options interface
+  $get<R extends Model<R>>(propertyKey: string, options?: any): Promise<R | R[]>; // TODO@robin options interface
 
   /**
    * Counts related instances (specified by propertyKey) of source instance


### PR DESCRIPTION
Reverts RobinBuschmann/sequelize-typescript#268

Hi @RobinBuschmann, after speaking to a colleague (@alfaproject) it seems I was incorrect here. I should be typecasting it as technically it can return R or R[]