### PR TITLE
Added sequelize.where to IBaseIncludeOptions 

### DIFF
--- a/lib/interfaces/IBaseIncludeOptions.ts
+++ b/lib/interfaces/IBaseIncludeOptions.ts
@@ -1,4 +1,4 @@
-import {WhereOptions, IncludeThroughOptions, FindOptionsAttributesArray} from 'sequelize';
+import {WhereOptions, IncludeThroughOptions, FindOptionsAttributesArray, where} from 'sequelize';
 
 /**
  * Complex include options
@@ -15,7 +15,7 @@ export interface IBaseIncludeOptions {
    * Where clauses to apply to the child models. Note that this converts the eager load to an inner join,
    * unless you explicitly set `required: false`
    */
-  where?: WhereOptions<any>;
+  where?: WhereOptions<any> | where;
 
   /**
    * A list of attributes to select from the child model


### PR DESCRIPTION
as there was compiling error when writing a find function line this `return await PublishedRoute.findAll({
            include: [{
                model: Route,
                where: sequelize.where(sequelize.col("PublishedRoute.versionId"), "=",
                    sequelize.col("routes.id")),
                include: [Stop]
            }]
        });`