### PR TITLE
Add static increment method to Model

### DIFF
--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -404,6 +404,27 @@ export declare abstract class Model<T extends Model<T>> extends Hooks {
   static restore(options?: RestoreOptions): Promise<void>;
 
   /**
+   * Increment the value of one or more columns. This is done in the database, which means it does not use the values currently stored on the Instance. The increment is done using a
+   * ```sql
+   * SET column = column + X WHERE foo = 'bar'
+   * ```
+   * query. To get the correct value after an increment into the Instance you should do a reload.
+   *
+   *```js
+  * Model.increment('number', { where: { foo: 'bar' }) // increment number by 1
+  * Model.increment(['number', 'count'], { by: 2, where: { foo: 'bar' } }) // increment number and count by 2
+  * Model.increment({ answer: 42, tries: -1}, { by: 2, where: { foo: 'bar' } }) // increment answer by 42, and decrement tries by 1.
+  *                                                        // `by` is ignored, since each column has its own value
+  * ```
+  *
+   * @param fields If a string is provided, that column is incremented by the value of `by` given in options.
+   *               If an array is provided, the same is true for each column.
+   *               If an object is provided, each column is incremented by the value given.
+  */
+  static increment<T extends Model<T>>(fields: string | string[] | Object,
+    options?: InstanceIncrementDecrementOptions & { silent?: boolean }): Promise<[Array<T>, number]> | Promise<[number, void]>;
+
+  /**
    * Update multiple instances that match the where options. The promise returns an array with one or two
    * elements. The first element is always the number of affected rows, while the second element is the actual
    * affected rows (only supported in postgres with `options.returning` true.)
@@ -646,7 +667,7 @@ export declare abstract class Model<T extends Model<T>> extends Hooks {
    *
    * @param fields If a string is provided, that column is incremented by the value of `by` given in options.
    *               If an array is provided, the same is true for each column.
-   *               If and object is provided, each column is incremented by the value given.
+   *               If an object is provided, each column is incremented by the value given.
    */
   increment(fields: string | string[] | Object,
             options?: InstanceIncrementDecrementOptions & { silent?: boolean }): Promise<this>;
@@ -669,7 +690,7 @@ export declare abstract class Model<T extends Model<T>> extends Hooks {
    *
    * @param fields If a string is provided, that column is decremented by the value of `by` given in options.
    *               If an array is provided, the same is true for each column.
-   *               If and object is provided, each column is decremented by the value given
+   *               If an object is provided, each column is decremented by the value given
    */
   decrement(fields: string | string[] | Object,
             options?: InstanceIncrementDecrementOptions & { silent?: boolean }): Promise<this>;


### PR DESCRIPTION
Fixes #276 

Originally I thought there was also a static decrement method but seems it's missing. Might be nice to add that upstream to Sequelize afterwards.

One thing I was confused about was why the `InstanceIncrementDecrementOptions` doesn't contain silent and it's extended afterwards. Guess I'll just leave it as it was for now. The description for the static increment was copied across from Sequelize too

Return type depends on if you pass in returning for Postgres: https://github.com/sequelize/sequelize/blob/master/lib/model.js#L2999

I did originally have `Promise<[Array<T>, number] | Promise<[number]>` but TS 2.7 requires fixed length tuples