### PR TITLE
Update Model.scope definition

### DIFF
--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -150,7 +150,7 @@ export declare abstract class Model<T extends Model<T>> extends Hooks {
    *     model will clear the previous scope.
    */
   static scope<T>(this: NonAbstractTypeOfModel<T>, options?: string | string[] | ScopeOptions | WhereOptions<any>): NonAbstractTypeOfModel<T>;
-  static scope<T>(this: NonAbstractTypeOfModel<T>, ...scopes: string[]): NonAbstractTypeOfModel<T>;
+  static scope<T>(this: NonAbstractTypeOfModel<T>, ...scopes: Array<string | ScopeOptions>): NonAbstractTypeOfModel<T>;
 
   /**
    * Search for multiple instances.


### PR DESCRIPTION
Allow simple scopes and scope functions together. For example:

```typescript
Product
  .scope('defaultScope', { method: ['company', companyId] })
  .find();
```