### PR TITLE
Set freezeTableName in global options and use those with all configs

### DIFF
--- a/lib/annotations/Table.ts
+++ b/lib/annotations/Table.ts
@@ -19,9 +19,6 @@ export function Table(arg: any): void|Function {
 }
 
 function annotate(target: any, options: IDefineOptions = {}): void {
-
-  if (options.freezeTableName === undefined) options.freezeTableName = true;
-
   options.instanceMethods = target.prototype;
   options.classMethods = target;
 

--- a/lib/models/v3/Sequelize.ts
+++ b/lib/models/v3/Sequelize.ts
@@ -23,9 +23,9 @@ export class Sequelize extends SequelizeOrigin implements BaseSequelize {
 
   constructor(config: SequelizeConfig | string) {
     if (typeof config === "string") {
-      super(config);
+      super(config, BaseSequelize.prepareConfig({url: config}));
     } else if (BaseSequelize.isISequelizeUriConfig(config)) {
-      super(config.url, config);
+      super(config.url, BaseSequelize.prepareConfig(config));
     } else {
       super(BaseSequelize.prepareConfig(config));
     }

--- a/lib/models/v4/Sequelize.ts
+++ b/lib/models/v4/Sequelize.ts
@@ -18,9 +18,9 @@ export class Sequelize extends OriginSequelize implements BaseSequelize {
 
   constructor(config: SequelizeConfig | string) {
     if (typeof config === "string") {
-      super(config);
+      super(config, BaseSequelize.prepareConfig({url: config}));
     } else if (BaseSequelize.isISequelizeUriConfig(config)) {
-      super(config.url, config);
+      super(config.url, BaseSequelize.prepareConfig(config));
     } else {
       super(BaseSequelize.prepareConfig(config));
     }

--- a/lib/services/models.ts
+++ b/lib/services/models.ts
@@ -13,7 +13,8 @@ const MODEL_NAME_KEY = 'sequelize:modelName';
 const ATTRIBUTES_KEY = 'sequelize:attributes';
 const OPTIONS_KEY = 'sequelize:options';
 export const DEFAULT_DEFINE_OPTIONS: DefineOptions<any> = {
-  timestamps: false
+  timestamps: false,
+  freezeTableName: true
 };
 export const PROPERTY_LINK_TO_ORIG = '__origClass';
 

--- a/test/specs/models/sequelize.spec.ts
+++ b/test/specs/models/sequelize.spec.ts
@@ -106,7 +106,7 @@ describe('sequelize', () => {
 
   describe('global define options', () => {
     describe('when created with uri string', () => {
-      const DEFINE_OPTIONS = {timestamps: false};
+      const DEFINE_OPTIONS = {timestamps: false, freezeTableName: true};
       const sequelizeFromUri = createSequelizeFromUri(false);
 
       it('should have default define options', () => {
@@ -133,7 +133,7 @@ describe('sequelize', () => {
     });
 
     describe('when created with uri object', () => {
-      const DEFINE_OPTIONS = {timestamps: false};
+      const DEFINE_OPTIONS = {timestamps: false, freezeTableName: true};
       const sequelizeFromUriObject = createSequelizeFromUriObject(false);
 
       it('should have define options', () => {
@@ -160,8 +160,15 @@ describe('sequelize', () => {
     });
 
     describe('when created with config object', () => {
-      const DEFINE_OPTIONS = {timestamps: true, underscoredAll: true};
-      const sequelizeFromUriObject = createSequelize(false, DEFINE_OPTIONS);
+      const DEFINE_OPTIONS = {
+        timestamps: true,
+        underscoredAll: true,
+        freezeTableName: true
+      };
+      const sequelizeFromUriObject = createSequelize(false, {
+        timestamps: true,
+        underscoredAll: true
+      });
 
       it('should have define options', () => {
         expect(sequelizeFromUriObject)

--- a/test/specs/models/sequelize.spec.ts
+++ b/test/specs/models/sequelize.spec.ts
@@ -1,7 +1,11 @@
 /* tslint:disable:max-classes-per-file */
 
 import {expect} from 'chai';
-import {createSequelize} from "../../utils/sequelize";
+import {
+  createSequelize,
+  createSequelizeFromUri,
+  createSequelizeFromUriObject
+} from '../../utils/sequelize';
 import {Game} from "../../models/exports/Game";
 import Gamer from "../../models/exports/gamer.model";
 import {Sequelize} from "../../../lib/models/Sequelize";
@@ -101,32 +105,86 @@ describe('sequelize', () => {
   });
 
   describe('global define options', () => {
+    describe('when created with uri string', () => {
+      const DEFINE_OPTIONS = {timestamps: false};
+      const sequelizeFromUri = createSequelizeFromUri(false);
 
-    const DEFINE_OPTIONS = {timestamps: true, underscoredAll: true};
-    const sequelizeWithDefine = createSequelize(false, DEFINE_OPTIONS);
+      it('should have default define options', () => {
+        expect(sequelizeFromUri)
+          .to.have.property('options')
+          .that.has.property('define')
+          .that.eqls(DEFINE_OPTIONS)
+          ;
+      });
 
-    it('should have define options', () => {
-      expect(sequelizeWithDefine)
-        .to.have.property('options')
-        .that.has.property('define')
-        .that.eqls(DEFINE_OPTIONS)
-        ;
+      it('should set define options for models', () => {
+        @Table
+        class User extends Model<User> {}
+        sequelizeFromUri.addModels([User]);
+
+        Object
+          .keys(DEFINE_OPTIONS)
+          .forEach(key => {
+            expect(User)
+              .to.have.property('options')
+              .that.have.property(key, DEFINE_OPTIONS[key]);
+          });
+      });
     });
 
-    it('should set define options for models', () => {
-      @Table
-      class User extends Model<User> {}
-      sequelizeWithDefine.addModels([User]);
+    describe('when created with uri object', () => {
+      const DEFINE_OPTIONS = {timestamps: false};
+      const sequelizeFromUriObject = createSequelizeFromUriObject(false);
 
-      Object
-        .keys(DEFINE_OPTIONS)
-        .forEach(key => {
-          expect(User)
-            .to.have.property('options')
-            .that.have.property(key, DEFINE_OPTIONS[key]);
-        });
+      it('should have define options', () => {
+        expect(sequelizeFromUriObject)
+          .to.have.property('options')
+          .that.has.property('define')
+          .that.eqls(DEFINE_OPTIONS)
+          ;
+      });
+
+      it('should set define options for models', () => {
+        @Table
+        class User extends Model<User> {}
+        sequelizeFromUriObject.addModels([User]);
+
+        Object
+          .keys(DEFINE_OPTIONS)
+          .forEach(key => {
+            expect(User)
+              .to.have.property('options')
+              .that.have.property(key, DEFINE_OPTIONS[key]);
+          });
+      });
     });
 
+    describe('when created with config object', () => {
+      const DEFINE_OPTIONS = {timestamps: true, underscoredAll: true};
+      const sequelizeFromUriObject = createSequelize(false, DEFINE_OPTIONS);
+
+      it('should have define options', () => {
+        expect(sequelizeFromUriObject)
+          .to.have.property('options')
+          .that.has.property('define')
+          .that.eqls(DEFINE_OPTIONS)
+          ;
+      });
+
+      it('should set define options for models', () => {
+        @Table
+        class User extends Model<User> {}
+        sequelizeFromUriObject.addModels([User]);
+
+        Object
+          .keys(DEFINE_OPTIONS)
+          .forEach(key => {
+            expect(User)
+              .to.have.property('options')
+              .that.have.property(key, DEFINE_OPTIONS[key]);
+          });
+      });
+    });
   });
 
   describe('addModels', () => {

--- a/test/specs/table_column.spec.ts
+++ b/test/specs/table_column.spec.ts
@@ -95,10 +95,10 @@ describe('table_column', () => {
       expect(shoeDefineOptions).not.to.be.undefined;
     });
 
-    it('should set freezeTableName to true', () => {
+    it('should not set freezeTableName', () => {
       const userDefineOptions = getOptions(User.prototype);
 
-      expect(userDefineOptions).to.have.property('freezeTableName', true);
+      expect(userDefineOptions).not.to.have.property('freezeTableName');
     });
 
     it('should have explicitly defined tableName', () => {

--- a/test/utils/sequelize.ts
+++ b/test/utils/sequelize.ts
@@ -39,6 +39,20 @@ export function createSequelizeValidationOnly(useModelsInPath: boolean = true): 
   });
 }
 
+export function createSequelizeFromUri(useModelsInPath: boolean = true): Sequelize {
+  const sequelize = new Sequelize('sqlite://');
+  sequelize.addModels(useModelsInPath ? [__dirname + '/../models'] : []);
+
+  return sequelize;
+}
+
+export function createSequelizeFromUriObject(useModelsInPath: boolean = true): Sequelize {
+  return new Sequelize({
+    url: 'sqlite://',
+    modelPaths: useModelsInPath ? [__dirname + '/../models'] : []
+  });
+}
+
 export function createOriginSequelize(): SequelizeType {
 
   return new OriginSequelize('___', 'root', '', {


### PR DESCRIPTION
Technically a breaking change is that global option defaults were not set if you would call `new Sequelize` with a `ISequelizeUriConfig` or just a uri. This behaviour has changed now, so some people may have had timestamps so far and won't get them anymore once this MR is published.

Technically I think this is a bug, as sequelize-typescript documents the behaviour without no timestamps by default. (Another difference with sequelize.)

I don't have any urgency to get this merged, so you may want to make this part of v1.0.0? Let me know if I should change the MR to target that branch.