### PR TITLE
added overloading for upsert and insertOrUpdate

### DIFF
--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -378,7 +378,7 @@ export declare abstract class Model<T extends Model<T>> extends Hooks {
   static upsert<A>(values: Partial<A>, options?: { returning: true } & UpsertOptions): Promise<[A, boolean]>;
 
   static insertOrUpdate<A>(values: Partial<A>, options?: { returning?: false } & UpsertOptions): Promise<boolean>;
-  static insertOrUpdate<A>(values: Partial<A>, options?: { returning: true } & UpsertOptions): Promise<[A, boolean}>;
+  static insertOrUpdate<A>(values: Partial<A>, options?: { returning: true } & UpsertOptions): Promise<[A, boolean]>;
 
   /**
    * Create and insert multiple instances in bulk.

--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -374,9 +374,11 @@ export declare abstract class Model<T extends Model<T>> extends Hooks {
    * because SQLite always runs INSERT OR IGNORE + UPDATE, in a single query, so there is no way to know
    * whether the row was inserted or not.
    */
-  static upsert<A>(values: A, options?: UpsertOptions): Promise<boolean>;
+  static upsert<A>(values: Partial<A>, options?: { returning?: false } & UpsertOptions): Promise<boolean>;
+  static upsert<A>(values: Partial<A>, options?: { returning: true } & UpsertOptions): Promise<[A, boolean]>;
 
-  static insertOrUpdate<A>(values: A, options?: UpsertOptions): Promise<boolean>;
+  static insertOrUpdate<A>(values: Partial<A>, options?: { returning?: false } & UpsertOptions): Promise<boolean>;
+  static insertOrUpdate<A>(values: Partial<A>, options?: { returning: true } & UpsertOptions): Promise<[A, boolean}>;
 
   /**
    * Create and insert multiple instances in bulk.


### PR DESCRIPTION
Hi there,

I'm not super familiar with `sequelize-typescript`, but I noticed that `upsert`/`insertOrUpdate` actually return a tuple inside a Promise, when `return: true` is used. This can probably be typed correctly with overloading.

In my case A is a model. Not sure if this covers all cases, though.