### PR TITLE
Added duplicating property to IBaseIncludeOptions

### DIFF
--- a/lib/interfaces/IBaseIncludeOptions.ts
+++ b/lib/interfaces/IBaseIncludeOptions.ts
@@ -29,6 +29,11 @@ export interface IBaseIncludeOptions {
   required?: boolean;
 
   /**
+   * Avoid cartesian product with assocations
+   */
+  duplicating?: boolean;
+
+  /**
    * Through Options
    */
   through?: IncludeThroughOptions;


### PR DESCRIPTION
This property allow a choice to avoid a cartesian product with assocations when using include. The actual Sequelize code is located at the line 487 of model.js. Also, this property in mentioned in multiple PR and Issues on Sequelize repo.