### PR TITLE
Updated reflect-metadata dependency handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,11 +70,6 @@
       "integrity": "sha1-xkZRE0YUyEuPXXEUzokB02pgl4A=",
       "dev": true
     },
-    "@types/reflect-metadata": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/reflect-metadata/-/reflect-metadata-0.0.4.tgz",
-      "integrity": "sha1-tkd8qal+UmXyrGf56nBOrl4Or00="
-    },
     "@types/sequelize": {
       "version": "4.27.20",
       "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.27.20.tgz",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@types/bluebird": "3.5.18",
     "@types/node": "6.0.41",
-    "@types/reflect-metadata": "0.0.4",
     "@types/sequelize": "4.27.20",
     "es6-shim": "0.35.3",
     "glob": "7.1.2"
@@ -80,6 +79,9 @@
     "tslint": "4.3.1",
     "typescript": "2.9.1",
     "uuid-validate": "0.0.2"
+  },
+  "peerDependencies": {
+    "reflect-metadata": ">=0.1.9"
   },
   "engines": {
     "node": ">=0.8.15"


### PR DESCRIPTION
Removed @types/reflect-metadata as the package bundles its own types
since 0.1.0.
Added reflect-metadata as peer dependency.

This resolves #407.