### PR TITLE
Allow boolean value on options.lock

### DIFF
--- a/lib/interfaces/IFindOptions.ts
+++ b/lib/interfaces/IFindOptions.ts
@@ -62,8 +62,8 @@ export interface IFindOptions<T> extends LoggingOptions, SearchPathOptions {
    * transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins.
    * See [transaction.LOCK for an example](transaction#lock)
    * 
-   * See [sequelize docs](https://github.com/sequelize/sequelize/blob/master/docs/transactions.md) for an
-   * example of boolean usage [https://github.com/sequelize/sequelize/blob/master/docs/transactions.md
+   * See [sequelize docs](https://github.com/sequelize/sequelize/blob/master/docs/transactions.md#after-commit-hook) for an
+   * example of boolean usage.
    */
   lock?: boolean | string | { level: string, of: typeof Model };
 

--- a/lib/interfaces/IFindOptions.ts
+++ b/lib/interfaces/IFindOptions.ts
@@ -57,7 +57,7 @@ export interface IFindOptions<T> extends LoggingOptions, SearchPathOptions {
   offset?: number;
 
   /**
-   * Lock the selected rows. A true boolean value will lock the request with a ' FOR UPDATE' lock. Possible 
+   * Lock the selected rows. A true boolean value will lock the request with a 'FOR UPDATE' lock. Possible 
    * additional options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports
    * transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins.
    * See [transaction.LOCK for an example](transaction#lock)

--- a/lib/interfaces/IFindOptions.ts
+++ b/lib/interfaces/IFindOptions.ts
@@ -57,11 +57,15 @@ export interface IFindOptions<T> extends LoggingOptions, SearchPathOptions {
   offset?: number;
 
   /**
-   * Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE.
-   * Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model
-   * locks with joins. See [transaction.LOCK for an example](transaction#lock)
+   * Lock the selected rows. A true boolean value will lock the request with a ' FOR UPDATE' lock. Possible 
+   * additional options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports
+   * transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins.
+   * See [transaction.LOCK for an example](transaction#lock)
+   * 
+   * See [sequelize docs](https://github.com/sequelize/sequelize/blob/master/docs/transactions.md) for an
+   * example of boolean usage [https://github.com/sequelize/sequelize/blob/master/docs/transactions.md
    */
-  lock?: string | { level: string, of: typeof Model };
+  lock?: boolean | string | { level: string, of: typeof Model };
 
   /**
    * Return raw result. See sequelize.query for more information.


### PR DESCRIPTION
Sequelize's documentation and code implementation allows a boolean value to be provided via `options.lock` in order to instantiate a 'for update' lock.

[An example of the `lock: true` usage with a `Model.findAll()` call](https://github.com/sequelize/sequelize/blob/master/docs/transactions.md#after-commit-hook)

[Usage inside sequelize's bundled tests](https://github.com/sequelize/sequelize/blob/bb874f5e7e0cc65a3ef70edd60d8ef24685fe3ec/test/integration/transaction.test.js#L531)