### PR TITLE
Fix the bug described in #446

### DIFF
--- a/lib/services/models.ts
+++ b/lib/services/models.ts
@@ -260,7 +260,6 @@ export function inferAlias(options: any, source: any): any {
   if (!Array.isArray(options.include)) {
     options.include = [options.include];
   } else if (!options.include.length) {
-    delete options.include;
     return options;
   }
 


### PR DESCRIPTION
* Delete a line in `inferAlias` that removes an empty `includes` object. Deleting this object actually can make Sequelize produce illegal SQL code.

Bug #446 describes this issue. The fix is trivial and seems harmless. All tests pass.