### PR TITLE
added findByPk method to the Model

### DIFF
--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -224,6 +224,8 @@ export declare abstract class Model<T extends Model<T>> extends Hooks {
    */
   static findById<T extends Model<T>>(this: (new () => T), identifier?: number | string, options?: IFindOptions<T>): Promise<T | null>;
 
+  static findByPk<T extends Model<T>>(this: (new () => T), identifier?: number | string, options?: IFindOptions<T>): Promise<T | null>;
+
   static findByPrimary<T extends Model<T>>(this: (new () => T), identifier?: number | string, options?: IFindOptions<T>): Promise<T | null>;
 
   /**


### PR DESCRIPTION
findById and findByPrimary are now deprecated
changes in sequelize: https://github.com/sequelize/sequelize/commit/1bc8b0e82d4635ff22cbd4c048c042fed30a036f

I wasn't sure if I should also push a PR to https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/sequelize, as the `findByPk` method was just added a few days ago (in above referenced commit), so if users aren't using the latest 4.x sequelize version.