### PR TITLE
Added the paranoid flag to the ICountOptions interface

### DIFF
--- a/lib/interfaces/ICountOptions.ts
+++ b/lib/interfaces/ICountOptions.ts
@@ -36,4 +36,10 @@ export interface ICountOptions<T> extends LoggingOptions, SearchPathOptions {
    * TODO: Check?
    */
   group?: Object;
+
+  /**
+   * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will
+   * be returned. Only applies if `options.paranoid` is true for the model.
+   */
+  paranoid?: boolean;
 }


### PR DESCRIPTION
Hi there, I added the missing paranoid flag to count options.

Now this is supported:
```ts
return Entity.count({
  paranoid: false,
});
```