### PR TITLE
Added missing hooks property for ICreateOptions

### DIFF
--- a/lib/interfaces/ICreateOptions.ts
+++ b/lib/interfaces/ICreateOptions.ts
@@ -10,4 +10,11 @@ export interface ICreateOptions extends IBuildOptions, InstanceSaveOptions {
    * On Duplicate
    */
   onDuplicate?: string;
+
+  /**
+   * Enable or disable hooks being triggered from this call
+   * @default false
+   */
+  hooks?: boolean;
+
 }

--- a/lib/interfaces/ICreateOptions.ts
+++ b/lib/interfaces/ICreateOptions.ts
@@ -13,7 +13,7 @@ export interface ICreateOptions extends IBuildOptions, InstanceSaveOptions {
 
   /**
    * Enable or disable hooks being triggered from this call
-   * @default false
+   * @default true
    */
   hooks?: boolean;
 


### PR DESCRIPTION
`hooks` property for ICreateOptions was missing as per the spec at http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-create. Rest of the properties seem to be fine. 

Thanks!