### PR TITLE
Add nest option for find

### DIFF
--- a/lib/interfaces/IFindOptions.ts
+++ b/lib/interfaces/IFindOptions.ts
@@ -71,6 +71,11 @@ export interface IFindOptions<T> extends LoggingOptions, SearchPathOptions {
   raw?: boolean;
 
   /**
+   * Nest raw results. See sequelize.query for more information.
+   */                  
+  nest?: boolean;
+
+  /**
    * having ?!?
    */
   having?: WhereOptions<any>;


### PR DESCRIPTION
While poorly documented find options derive from query options which include the nest option. Added it in as it's a pretty usefull option to have.