### PR TITLE
fix typing definition of Model.$set

### DIFF
--- a/lib/models/Model.d.ts
+++ b/lib/models/Model.d.ts
@@ -470,7 +470,7 @@ export declare abstract class Model<T extends Model<T>> extends Hooks {
    * Sets relation between specified instances and source instance
    * (replaces old relations)
    */
-  $set<R extends Model<R>>(propertyKey: string, instances: R | R[] | string[] | string | number[] | number, options?: IAssociationActionOptions): Promise<this>;
+  $set<R extends Model<R>>(propertyKey: string, instances: R | R[] | string[] | string | number[] | number, options?: any): Promise<this>;
 
   /**
    * Returns related instance (specified by propertyKey) of source instance


### PR DESCRIPTION
current typing definition for Model.$set method  seems to be wrong.

docs: http://docs.sequelizejs.com/class/lib/associations/belongs-to.js~BelongsTo.html#instance-method-set


This problem is also mentioned here.
https://github.com/RobinBuschmann/sequelize-typescript/issues/244#issuecomment-413635439
