### PR TITLE
Add `save` to IAssociationActionOptions

### DIFF
--- a/lib/interfaces/IAssociationActionOptions.ts
+++ b/lib/interfaces/IAssociationActionOptions.ts
@@ -2,4 +2,5 @@
 export interface IAssociationActionOptions {
   through?: any;
   transaction?: any;
+  save?: boolean;
 }


### PR DESCRIPTION
Fixes #244 #493

Related documenation: http://docs.sequelizejs.com/class/lib/associations/belongs-to.js~BelongsTo.html#instance-method-set