### PR TITLE
Allow string type when defining associations to be loaded eagerly...

### DIFF
--- a/lib/interfaces/IIncludeOptions.ts
+++ b/lib/interfaces/IIncludeOptions.ts
@@ -15,7 +15,7 @@ export interface IIncludeOptions extends IBaseIncludeOptions {
   /**
    * The association you want to eagerly load. (This can be used instead of providing a model/as pair)
    */
-  association?: IIncludeAssociation;
+  association?: IIncludeAssociation | string;
 
   /**
    * Load further nested related models

--- a/lib/types/ModelClassGetter.ts
+++ b/lib/types/ModelClassGetter.ts
@@ -1,3 +1,3 @@
 import {Model} from "../models/Model";
 
-export type ModelClassGetter = () => typeof Model;
+export type ModelClassGetter = (returns?: void) => typeof Model;


### PR DESCRIPTION
Related to: #486 

+ allow a fake argument in ModelClassGetter function to follow convention from many other libraries like TypeORM or TypeGraphQL example:
```ts
@Table
export default class User extends Model<User>
{
	@HasMany(type => Post) // instead of () => Post
	posts: Post[]
}
```