### PR TITLE
Align @Column type parameter to match the Sequelize

### DIFF
--- a/src/model/column/column.ts
+++ b/src/model/column/column.ts
@@ -1,10 +1,10 @@
-import {ModelAttributeColumnOptions, DataTypeAbstract} from 'sequelize';
+import {ModelAttributeColumnOptions, DataType} from 'sequelize';
 
 import {addAttribute} from './attribute-service';
 import {isDataType} from "../../sequelize/data-type/data-type-service";
 import {getSequelizeTypeByDesignType} from "../shared/model-service";
 
-export function Column(dataType: DataTypeAbstract): Function;
+export function Column(dataType: DataType): Function;
 export function Column(options: Partial<ModelAttributeColumnOptions>): Function;
 export function Column(target: any, propertyName: string, propertyDescriptor?: PropertyDescriptor): void;
 export function Column(...args: any[]): Function | void {
@@ -29,14 +29,14 @@ export function Column(...args: any[]): Function | void {
 function annotate(target: any,
                   propertyName: string,
                   propertyDescriptor?: PropertyDescriptor,
-                  optionsOrDataType: Partial<ModelAttributeColumnOptions> | DataTypeAbstract = {}): void {
+                  optionsOrDataType: Partial<ModelAttributeColumnOptions> | DataType = {}): void {
 
   let options: Partial<ModelAttributeColumnOptions>;
 
   if (isDataType(optionsOrDataType)) {
 
     options = {
-      type: optionsOrDataType as DataTypeAbstract
+      type: optionsOrDataType
     };
   } else {
 

--- a/src/sequelize/data-type/data-type-service.ts
+++ b/src/sequelize/data-type/data-type-service.ts
@@ -5,7 +5,8 @@ import {DataType, DataTypeAbstract, DataTypes} from 'sequelize';
  */
 export function isDataType(value: any): value is DataType {
 
-  return (typeof value === 'function' && value({}) instanceof (DataTypes.ABSTRACT as any)) ||
+  return typeof value === 'string' ||
+    (typeof value === 'function' && value({}) instanceof (DataTypes.ABSTRACT as any)) ||
     value instanceof (DataTypes.ABSTRACT as any);
 }
 

--- a/src/sequelize/data-type/data-type-service.ts
+++ b/src/sequelize/data-type/data-type-service.ts
@@ -1,16 +1,12 @@
-import {DataTypeAbstract} from 'sequelize';
-import {DataType} from './data-type';
+import {DataType, DataTypeAbstract, DataTypes} from 'sequelize';
 
 /*
  * Checks if specified value is a sequelize data type (ABSTRACT, STRING...)
  */
-export function isDataType(value: any): boolean {
+export function isDataType(value: any): value is DataType {
 
-  return value === DataType.ABSTRACT ||
-    value === DataType.NUMBER ||
-    (typeof value === 'function' &&
-      value({}) instanceof (DataType.ABSTRACT as any)) ||
-    value instanceof (DataType.ABSTRACT as any);
+  return (typeof value === 'function' && value({}) instanceof (DataTypes.ABSTRACT as any)) ||
+    value instanceof (DataTypes.ABSTRACT as any);
 }
 
 /**
@@ -20,15 +16,15 @@ export function inferDataType(designType: any): DataTypeAbstract | undefined {
 
   switch (designType) {
     case String:
-      return DataType.STRING;
+      return DataTypes.STRING;
     case Number:
-      return DataType.INTEGER;
+      return DataTypes.INTEGER;
     case Boolean:
-      return DataType.BOOLEAN;
+      return DataTypes.BOOLEAN;
     case Date:
-      return DataType.DATE;
+      return DataTypes.DATE;
     case Buffer:
-      return DataType.BLOB;
+      return DataTypes.BLOB;
     default:
       return void 0;
   }

--- a/src/sequelize/data-type/data-type.ts
+++ b/src/sequelize/data-type/data-type.ts
@@ -1,3 +1,3 @@
-import * as Sequelize from "sequelize";
+import { DataTypes } from 'sequelize';
 
-export const DataType: typeof Sequelize = Sequelize;
+export const DataType: typeof DataTypes = DataTypes;

--- a/test/models/User.ts
+++ b/test/models/User.ts
@@ -63,6 +63,9 @@ export class User extends Model<User> {
   @Column
   email: string;
 
+  @Column('VARCHAR(255)')
+  city: string;
+
   extraField: string;
   extraField2: boolean;
   extraField3: number;

--- a/test/specs/utils/data-type.spec.ts
+++ b/test/specs/utils/data-type.spec.ts
@@ -24,6 +24,7 @@ describe('utils', () => {
 
         expect(isDataType(DataType.STRING(55))).to.be.true;
         expect(isDataType(DataType.ENUM('a', 'b'))).to.be.true;
+        expect(isDataType(DataType.ARRAY(DataType.STRING))).to.be.true;
       });
 
       it('should return false', () => {

--- a/test/specs/utils/data-type.spec.ts
+++ b/test/specs/utils/data-type.spec.ts
@@ -25,11 +25,11 @@ describe('utils', () => {
         expect(isDataType(DataType.STRING(55))).to.be.true;
         expect(isDataType(DataType.ENUM('a', 'b'))).to.be.true;
         expect(isDataType(DataType.ARRAY(DataType.STRING))).to.be.true;
+        expect(isDataType('VARCHAR(255)')).to.be.true;
       });
 
       it('should return false', () => {
 
-        expect(isDataType('abc')).to.be.false;
         expect(isDataType(function(): void {})).to.be.false;
         expect(isDataType(() => null)).to.be.false;
         expect(isDataType({})).to.be.false;

--- a/test/types/model.spec.ts
+++ b/test/types/model.spec.ts
@@ -1,0 +1,12 @@
+// Types only test. This should compile successfully.
+
+import {Column} from '../../src/model/column/column';
+import {Model} from '../../src/model/model/model';
+import {Table} from '../../src/model/table/table';
+import {DataType} from '../../src/sequelize/data-type/data-type';
+
+@Table
+export class User extends Model<User> {
+  @Column(DataType.ARRAY(DataType.STRING))
+  myCol: string[];
+}


### PR DESCRIPTION
See #594 for an example. This PR allows to pass any type allowed by the Sequelize to `@Column` annotation.

1. Sequelize seems to allow `string` as a type (e.g. `@Column('STRING')`), but there is a test, which fails in this case. Shall I also allow this and change test or keep it as it is now?
2. I'm not sure how to add a test for the `@Column(ARRAY(STRING))` fix as tests seems to run against Sqlite and it does not support ARRAY type. Any suggestions?

Fixes #594 
