### PR TITLE
Moving sequelize and node to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,11 @@
     "@types/chai-datetime": "0.0.30",
     "@types/lodash": "4.14.109",
     "@types/mocha": "2.2.39",
+    "@types/node": "11.12.2"
     "@types/prettyjson": "0.0.28",
     "@types/sinon": "1.16.35",
     "@types/sinon-chai": "2.7.27",
+    "@types/sequelize": "4.27.48",
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",
     "chai-datetime": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/chai-datetime": "0.0.30",
     "@types/lodash": "4.14.109",
     "@types/mocha": "2.2.39",
-    "@types/node": "11.12.2"
+    "@types/node": "11.12.2",
     "@types/prettyjson": "0.0.28",
     "@types/sinon": "1.16.35",
     "@types/sinon-chai": "2.7.27",

--- a/package.json
+++ b/package.json
@@ -44,10 +44,12 @@
   "types": "index.d.ts",
   "dependencies": {
     "@types/bluebird": "3.5.26",
-    "@types/node": "11.12.2",
-    "@types/sequelize": "4.27.48",
     "es6-shim": "0.35.3",
     "glob": "7.1.2"
+  },
+  "peerDependencies" : {
+    "@types/sequelize": "4.27.48",
+    "@types/node": "11.12.2"
   },
   "devDependencies": {
     "@types/chai": "3.4.35",


### PR DESCRIPTION
Moving sequelize and node to peerDependencies

This makes it a lot easier to fix/patch type issues that sequelize-typescript depends on.