### PR TITLE
Update association-get-options.ts

### DIFF
--- a/src/model/model/association/association-get-options.ts
+++ b/src/model/model/association/association-get-options.ts
@@ -1,6 +1,6 @@
 import {FindOptions} from "sequelize";
 
 export type AssociationGetOptions = {
-  scope?: string | boolean;
+  scope?: string | string[] | boolean;
   schema?: string;
 } & FindOptions;


### PR DESCRIPTION
We can also specify multiple scopes through that option.

```javascript
// house model with a persons associations
house.$get('persons', { scope: ['includeChildrenStat', 'includeElderStat'] })

```