### PR TITLE
Allow model generics in Table decorator

### DIFF
--- a/src/model/table/table-options.ts
+++ b/src/model/table/table-options.ts
@@ -1,6 +1,6 @@
-import {ModelOptions} from "sequelize";
+import {Model, ModelOptions} from "sequelize";
 
-export interface TableOptions extends ModelOptions {
+export interface TableOptions<M extends Model = Model> extends ModelOptions<M> {
   modelName?: string;
 
   /**

--- a/src/model/table/table.ts
+++ b/src/model/table/table.ts
@@ -2,7 +2,7 @@ import {TableOptions} from "./table-options";
 import {Model} from "../model/model";
 import {setModelName, addOptions} from "../shared/model-service";
 
-export function Table(options: TableOptions): Function;
+export function Table<M extends Model = Model>(options: TableOptions<M>): Function;
 export function Table(target: Function): void;
 export function Table(arg: any): void | Function {
 

--- a/test/types/model.spec.ts
+++ b/test/types/model.spec.ts
@@ -10,3 +10,16 @@ export class User extends Model {
   @Column(DataType.ARRAY(DataType.STRING))
   myCol: string[];
 }
+
+@Table<Post>({
+  hooks: {
+    beforeUpdate: (instance) => {
+      // without generic random will result in error
+      instance.random = 4;
+    },
+  },
+})
+export class Post extends Model {
+  @Column(DataType.INTEGER)
+  random: number;
+}


### PR DESCRIPTION
This PR helps when writing `@Table` definitions with hooks or other model-dependent options. I'm ignoring other decorators like `@Column` since these don't have any use from model.

__I can use some help with updating docs, since I'm not a native speaker nor have any idea what I'm doing__

```ts
@Table<Post>({
  hooks: {
    beforeUpdate: (instance) => {
      // this will result in error before PR
      instance.random = 4;
    },
  },
})
export class Post extends Model {
  @Column(DataType.INTEGER)
  random: number;
}

// alternative which works even now
@Table({
  hooks: {
    beforeUpdate: (instance: Post) => {
      // this works ok
      instance.random = 4;
    },
  },
})
```