### PR TITLE
Made AllowNull decorator code consistent to others

### DIFF
--- a/src/model/column/column-options/allow-null.ts
+++ b/src/model/column/column-options/allow-null.ts
@@ -1,25 +1,36 @@
-import {addAttributeOptions} from '../attribute-service';
+import { addAttributeOptions } from "../attribute-service";
+
+type AllowNullOption = boolean;
 
 /**
- * Sets allowNull true for annotated property column.
+ * Sets allowNull option as specified in options and returns decorator
  */
-export function AllowNull(target: any, propertyName: string): void;
-export function AllowNull(allowNull: boolean): Function;
+export function AllowNull(options: AllowNullOption): Function;
+
+/**
+ * Decorator, which sets allowNull option true for annotated property.
+ */
+export function AllowNull(target: Object, propertyName: string): void;
+
 export function AllowNull(...args: any[]): void | Function {
-
   if (args.length === 1) {
+    const [options] = args;
 
-    const allowNull = args[0];
-
-    return (target: any, propertyName: string) =>
-      addAttributeOptions(target, propertyName, {allowNull});
-  } else {
-
-    const target = args[0];
-    const propertyName = args[1];
-
-    addAttributeOptions(target, propertyName, {
-      allowNull: true
-    });
+    return (_target, _propertyName) => {
+      annotate(_target, _propertyName, options);
+    };
   }
+
+  const [target, propertyName] = args;
+  annotate(target, propertyName);
+}
+
+function annotate(
+  target: Object,
+  propertyName: string,
+  option: AllowNullOption = true
+) {
+  addAttributeOptions(target, propertyName, {
+    allowNull: option,
+  });
 }

--- a/src/model/column/column-options/unique.ts
+++ b/src/model/column/column-options/unique.ts
@@ -1,4 +1,4 @@
-import {addAttributeOptions} from "../attribute-service";
+import { addAttributeOptions } from "../attribute-service";
 
 type UniqueOptions = boolean | string | { name: string; msg: string };
 
@@ -15,15 +15,21 @@ export function Unique(target: Object, propertyName: string): void;
 export function Unique(...args: any[]): void | Function {
   if (args.length === 1) {
     const [options] = args;
+
     return (_target, _propertyName) => {
       annotate(_target, _propertyName, options);
     };
   }
+
   const [target, propertyName] = args;
   annotate(target, propertyName);
 }
 
-function annotate(target: Object, propertyName: string, option: UniqueOptions = true) {
+function annotate(
+  target: Object,
+  propertyName: string,
+  option: UniqueOptions = true
+) {
   addAttributeOptions(target, propertyName, {
     unique: option,
   });


### PR DESCRIPTION
Declared a type for AllowNullOption in the AllowNull decorator and made the code consistent to Unique decorator.