### PR TITLE
Pass models object in association annotations

### DIFF
--- a/src/associations/belongs-to-many/belongs-to-many-association.ts
+++ b/src/associations/belongs-to-many/belongs-to-many-association.ts
@@ -33,7 +33,7 @@ export class BelongsToManyAssociation<
     const options: BelongsToManyOptions<TCreationAttributesThrough, TModelAttributesThrough> = {
       ...this.options,
     };
-    const associatedClass = this.getAssociatedClass(sequelize.getModelObject());
+    const associatedClass = this.getAssociatedClass(sequelize.stModels);
     const throughOptions = this.getThroughOptions(sequelize);
 
     const throughModel =
@@ -41,9 +41,15 @@ export class BelongsToManyAssociation<
         ? throughOptions.model
         : undefined;
     options.through = throughOptions;
-    options.foreignKey = getForeignKeyOptions(model, throughModel as any, this.options.foreignKey);
+    options.foreignKey = getForeignKeyOptions(
+      model,
+      sequelize,
+      throughModel as any,
+      this.options.foreignKey
+    );
     options.otherKey = getForeignKeyOptions(
       associatedClass,
+      sequelize,
       throughModel as any,
       this.options.otherKey
     );
@@ -60,7 +66,7 @@ export class BelongsToManyAssociation<
       typeof through === 'object' ? { ...through } : ({} as any);
 
     if (typeof throughModel === 'function') {
-      const throughModelClass = sequelize.model(throughModel(sequelize.getModelObject()));
+      const throughModelClass = sequelize.model(throughModel(sequelize.stModels));
       if (!throughModelClass.isInitialized) {
         throw new ModelNotInitializedError(throughModelClass, 'Association cannot be resolved.');
       }

--- a/src/associations/belongs-to-many/belongs-to-many-association.ts
+++ b/src/associations/belongs-to-many/belongs-to-many-association.ts
@@ -33,7 +33,7 @@ export class BelongsToManyAssociation<
     const options: BelongsToManyOptions<TCreationAttributesThrough, TModelAttributesThrough> = {
       ...this.options,
     };
-    const associatedClass = this.getAssociatedClass();
+    const associatedClass = this.getAssociatedClass(sequelize.getModelObject());
     const throughOptions = this.getThroughOptions(sequelize);
 
     const throughModel =
@@ -60,7 +60,7 @@ export class BelongsToManyAssociation<
       typeof through === 'object' ? { ...through } : ({} as any);
 
     if (typeof throughModel === 'function') {
-      const throughModelClass = sequelize.model(throughModel());
+      const throughModelClass = sequelize.model(throughModel(sequelize.getModelObject()));
       if (!throughModelClass.isInitialized) {
         throw new ModelNotInitializedError(throughModelClass, 'Association cannot be resolved.');
       }

--- a/src/associations/belongs-to/belongs-to-association.ts
+++ b/src/associations/belongs-to/belongs-to-association.ts
@@ -6,6 +6,7 @@ import { ModelClassGetter } from '../../model/shared/model-class-getter';
 import { Association } from '../shared/association';
 import { ModelType } from '../../model/model/model';
 import { UnionAssociationOptions } from '../shared/union-association-options';
+import { Sequelize } from '../../sequelize/sequelize/sequelize';
 
 export class BelongsToAssociation<TCreationAttributes, TModelAttributes> extends BaseAssociation<
   TCreationAttributes,
@@ -23,9 +24,10 @@ export class BelongsToAssociation<TCreationAttributes, TModelAttributes> extends
   }
 
   getSequelizeOptions(
-    model: ModelType<TCreationAttributes, TModelAttributes>
+    model: ModelType<TCreationAttributes, TModelAttributes>,
+    sequelize: Sequelize
   ): UnionAssociationOptions {
-    const associatedClass = this.getAssociatedClass();
+    const associatedClass = this.getAssociatedClass(sequelize.getModelObject());
     const foreignKey = getForeignKeyOptions(associatedClass, model, this.options.foreignKey);
 
     return {

--- a/src/associations/belongs-to/belongs-to-association.ts
+++ b/src/associations/belongs-to/belongs-to-association.ts
@@ -27,8 +27,13 @@ export class BelongsToAssociation<TCreationAttributes, TModelAttributes> extends
     model: ModelType<TCreationAttributes, TModelAttributes>,
     sequelize: Sequelize
   ): UnionAssociationOptions {
-    const associatedClass = this.getAssociatedClass(sequelize.getModelObject());
-    const foreignKey = getForeignKeyOptions(associatedClass, model, this.options.foreignKey);
+    const associatedClass = this.getAssociatedClass(sequelize.stModels);
+    const foreignKey = getForeignKeyOptions(
+      associatedClass,
+      sequelize,
+      model,
+      this.options.foreignKey
+    );
 
     return {
       ...this.options,

--- a/src/associations/foreign-key/foreign-key-service.ts
+++ b/src/associations/foreign-key/foreign-key-service.ts
@@ -3,6 +3,7 @@ import { ForeignKeyOptions } from 'sequelize';
 import { ForeignKeyMeta } from './foreign-key-meta';
 import { ModelClassGetter } from '../../model/shared/model-class-getter';
 import { ModelType } from '../../model/model/model';
+import { Sequelize } from '../../sequelize/sequelize/sequelize';
 
 const FOREIGN_KEYS_KEY = 'sequelize:foreignKeys';
 
@@ -13,6 +14,7 @@ export function getForeignKeyOptions<
   TModelAttributesThrough
 >(
   relatedClass: ModelType<TCreationAttributes, TModelAttributes>,
+  sequelize: Sequelize,
   classWithForeignKey?: ModelType<TCreationAttributesThrough, TModelAttributesThrough>,
   foreignKey?: string | ForeignKeyOptions
 ): ForeignKeyOptions {
@@ -27,8 +29,8 @@ export function getForeignKeyOptions<
     const foreignKeys = getForeignKeys(classWithForeignKey.prototype) || [];
     for (const key of foreignKeys) {
       if (
-        key.relatedClassGetter() === relatedClass ||
-        relatedClass.prototype instanceof key.relatedClassGetter()
+        key.relatedClassGetter(sequelize.stModels) === relatedClass ||
+        relatedClass.prototype instanceof key.relatedClassGetter(sequelize.stModels)
       ) {
         foreignKeyOptions.name = key.foreignKey;
         break;

--- a/src/associations/has/has-association.ts
+++ b/src/associations/has/has-association.ts
@@ -6,7 +6,7 @@ import { ModelClassGetter } from '../../model/shared/model-class-getter';
 import { Association } from '../shared/association';
 import { UnionAssociationOptions } from '../shared/union-association-options';
 import { ModelType } from '../../model/model/model';
-
+import { Sequelize } from '../../sequelize/sequelize/sequelize';
 export class HasAssociation<TCreationAttributes, TModelAttributes> extends BaseAssociation<
   TCreationAttributes,
   TModelAttributes
@@ -24,10 +24,11 @@ export class HasAssociation<TCreationAttributes, TModelAttributes> extends BaseA
   }
 
   getSequelizeOptions(
-    model: ModelType<TCreationAttributes, TModelAttributes>
+    model: ModelType<TCreationAttributes, TModelAttributes>,
+    sequelize: Sequelize
   ): UnionAssociationOptions {
     const options = { ...this.options };
-    const associatedClass = this.getAssociatedClass();
+    const associatedClass = this.getAssociatedClass(sequelize.getModelObject());
 
     options.foreignKey = getForeignKeyOptions(model, associatedClass, options.foreignKey);
 

--- a/src/associations/has/has-association.ts
+++ b/src/associations/has/has-association.ts
@@ -28,9 +28,14 @@ export class HasAssociation<TCreationAttributes, TModelAttributes> extends BaseA
     sequelize: Sequelize
   ): UnionAssociationOptions {
     const options = { ...this.options };
-    const associatedClass = this.getAssociatedClass(sequelize.getModelObject());
+    const associatedClass = this.getAssociatedClass(sequelize.stModels);
 
-    options.foreignKey = getForeignKeyOptions(model, associatedClass, options.foreignKey);
+    options.foreignKey = getForeignKeyOptions(
+      model,
+      sequelize,
+      associatedClass,
+      options.foreignKey
+    );
 
     return options;
   }

--- a/src/associations/shared/association-service.ts
+++ b/src/associations/shared/association-service.ts
@@ -68,11 +68,13 @@ export function getAssociationsByRelation<TCreationAttributes, TModelAttributes>
 ): BaseAssociation<TCreationAttributes, TModelAttributes>[] {
   const associations = getAssociations<TCreationAttributes, TModelAttributes>(target);
   return (associations || []).filter((association) => {
-    
-    const modelObject: ModelObject =(relatedClass as Model).sequelize.modelManager.models.reduce((acc, model) => {
-      acc[getModelName(model.prototype)] = model;
-      return acc;
-    }, {});
+    const modelObject: ModelObject = (relatedClass as Model).sequelize.modelManager.models.reduce(
+      (acc, model) => {
+        acc[getModelName(model.prototype)] = model;
+        return acc;
+      },
+      {}
+    );
     const _relatedClass = association.getAssociatedClass(modelObject);
     return (
       _relatedClass.prototype === relatedClass.prototype ||

--- a/src/associations/shared/association-service.ts
+++ b/src/associations/shared/association-service.ts
@@ -1,6 +1,8 @@
 import 'reflect-metadata';
 import { BelongsToOptions, HasOneOptions, HasManyOptions, ManyToManyOptions } from 'sequelize';
 import { BaseAssociation } from './base-association';
+import { Model, ModelObject } from '../../model/model/model';
+import { getModelName } from '../../model/shared/model-service';
 
 const ASSOCIATIONS_KEY = 'sequelize:associations';
 
@@ -66,7 +68,12 @@ export function getAssociationsByRelation<TCreationAttributes, TModelAttributes>
 ): BaseAssociation<TCreationAttributes, TModelAttributes>[] {
   const associations = getAssociations<TCreationAttributes, TModelAttributes>(target);
   return (associations || []).filter((association) => {
-    const _relatedClass = association.getAssociatedClass();
+    
+    const modelObject: ModelObject =(relatedClass as Model).sequelize.modelManager.models.reduce((acc, model) => {
+      acc[getModelName(model.prototype)] = model;
+      return acc;
+    }, {});
+    const _relatedClass = association.getAssociatedClass(modelObject);
     return (
       _relatedClass.prototype === relatedClass.prototype ||
       relatedClass.prototype instanceof _relatedClass

--- a/src/associations/shared/base-association.ts
+++ b/src/associations/shared/base-association.ts
@@ -1,7 +1,7 @@
 import { UnionAssociationOptions } from './union-association-options';
 import { Association } from './association';
 import { ModelClassGetter } from '../../model/shared/model-class-getter';
-import { ModelType } from '../../model/model/model';
+import { ModelType, ModelObject } from '../../model/model/model';
 import { Sequelize } from '../../sequelize/sequelize/sequelize';
 
 export abstract class BaseAssociation<TCreationAttributes, TModelAttributes> {
@@ -16,8 +16,8 @@ export abstract class BaseAssociation<TCreationAttributes, TModelAttributes> {
     sequelize: Sequelize
   ): UnionAssociationOptions;
 
-  getAssociatedClass(): ModelType<TCreationAttributes, TModelAttributes> {
-    return this.associatedClassGetter();
+  getAssociatedClass(models: ModelObject): ModelType<TCreationAttributes, TModelAttributes> {
+    return this.associatedClassGetter(models);
   }
 
   getAs(): string | { singular: string; plural: string } | undefined {

--- a/src/model/model/model.ts
+++ b/src/model/model/model.ts
@@ -24,7 +24,7 @@ export type ModelStatic<M extends Model = Model> = { new (): M };
 
 export type $GetType<T> = NonNullable<T> extends any[] ? NonNullable<T> : NonNullable<T> | null;
 export interface ModelObject {
-  [key: string]: ModelCtor | Model;
+  [key: string]: ModelCtor<Model>;
 }
 export abstract class Model<
   TModelAttributes extends {} = any,

--- a/src/model/model/model.ts
+++ b/src/model/model/model.ts
@@ -23,7 +23,9 @@ export type ModelCtor<M extends Model = Model> = Repository<M>;
 export type ModelStatic<M extends Model = Model> = { new (): M };
 
 export type $GetType<T> = NonNullable<T> extends any[] ? NonNullable<T> : NonNullable<T> | null;
-
+export interface ModelObject {
+  [key: string]: ModelCtor | Model;
+}
 export abstract class Model<
   TModelAttributes extends {} = any,
   TCreationAttributes extends {} = TModelAttributes

--- a/src/model/shared/model-class-getter.ts
+++ b/src/model/shared/model-class-getter.ts
@@ -1,5 +1,6 @@
-import { ModelType } from '../model/model';
+import { ModelType, ModelObject } from '../model/model';
 
 export type ModelClassGetter<TCreationAttributes, TModelAttributes> = (
+  modelObject: ModelObject,
   returns?: void
 ) => ModelType<TCreationAttributes, TModelAttributes>;

--- a/src/sequelize/sequelize/sequelize.ts
+++ b/src/sequelize/sequelize/sequelize.ts
@@ -2,7 +2,7 @@ import { InitOptions, Sequelize as OriginSequelize } from 'sequelize';
 import { ModelNotInitializedError } from '../../model/shared/model-not-initialized-error';
 import { ModelMatch, SequelizeOptions } from './sequelize-options';
 import { getModels, prepareArgs } from './sequelize-service';
-import { Model, ModelCtor, ModelType } from '../../model/model/model';
+import { Model, ModelCtor, ModelType, ModelObject } from '../../model/model/model';
 import { getModelName, getOptions } from '../../model/shared/model-service';
 import { resolveScopes } from '../../scopes/scope-service';
 import { installHooks } from '../../hooks/shared/hooks-service';
@@ -59,7 +59,16 @@ export class Sequelize extends OriginSequelize {
     return this.model(modelClass as any) as Repository<M>;
   }
 
+  getModelObject(): ModelObject {
+    const modelObject: ModelObject = this.modelManager.models.reduce((acc, model) => {
+      acc[getModelName(model.prototype)] = model;
+      return acc;
+    }, {});
+    return modelObject;
+  }
+
   private associateModels(models: ModelCtor[]): void {
+    const modelObject = this.getModelObject();
     models.forEach((model) => {
       const associations = getAssociations(model.prototype);
 
@@ -67,7 +76,7 @@ export class Sequelize extends OriginSequelize {
 
       associations.forEach((association) => {
         const options = association.getSequelizeOptions(model, this);
-        const associatedClass = this.model(association.getAssociatedClass());
+        const associatedClass = this.model(association.getAssociatedClass(modelObject));
 
         if (!associatedClass.isInitialized) {
           throw new ModelNotInitializedError(


### PR DESCRIPTION
I've had a number of issues with cyclical dependencies. TDLR, if I install the webpack CircularDependencyPlugin on my project (NextJS, apollo graphql, sequelize, react, typescript), the build would fail because of cyclical dependency errors caused by sequelize-typescript requiring cyclical model import. After trying various things, I had a hunch that passing an object with all initialized models object in @HasMany, @BelongsTo etc might resolve this issue (even though you still need the cyclical imports because of the direct reference to the associated model the model definition needs). 

To my surprise, it worked. With the adjustments I made 
```
@BelongsTo(() => User, {
    foreignKey: 'userId',
    as: 'user',
})
public user!: User;
```

becomes

``` 
@BelongsTo((models) => models.User, {
    foreignKey: 'userId',
    as: 'user',
})
public user!: User;
```

and the circular dependency errors disappear. 

If this change makes sense, I can add some documentation. But for now, I'm assuming it might be rejected, so I'll leave it for consideration. Ideally, IMHO initialization and association should be separate passes so any reference to another model can occur through a models object and not require cyclical imports of models. 